### PR TITLE
fix: should flush ui command before evaluate script when parse html.

### DIFF
--- a/bridge/core/html/parser/html_parser.cc
+++ b/bridge/core/html/parser/html_parser.cc
@@ -79,6 +79,7 @@ void HTMLParser::traverseHTML(Node* root_node, GumboNode* node) {
         if (child->v.element.children.length > 0) {
           if (child->v.element.tag == GUMBO_TAG_SCRIPT) {
             const char* code = ((GumboNode*)child->v.element.children.data[0])->v.text.text;
+            context->FlushUICommand();
             context->EvaluateJavaScript(code, strlen(code), "vm://", 0);
           } else {
             traverseHTML(element, child);


### PR DESCRIPTION
Support query dom element in the inline script at the bottom of the body.

```html
<!DOCTYPE html>
<html>
  <body>
  <div id="button"> Button</div>
    <div class="container"></div>
    <script>
      let button = document.getElementById('button');
    </script>
  </body>
</html>
```