### PR TITLE
Fix: ios build

### DIFF
--- a/webf/ios/Frameworks/quickjs.xcframework
+++ b/webf/ios/Frameworks/quickjs.xcframework
@@ -1,0 +1,1 @@
+../../../bridge/build/ios/framework/quickjs.xcframework

--- a/webf/ios/Frameworks/webf_bridge.xcframework
+++ b/webf/ios/Frameworks/webf_bridge.xcframework
@@ -1,0 +1,1 @@
+../../../bridge/build/ios/framework/webf_bridge.xcframework

--- a/webf/ios/prepare.sh
+++ b/webf/ios/prepare.sh
@@ -1,13 +1,12 @@
-ROOT=$(pwd)
+ROOT=$(pwd)/Frameworks
+cd $ROOT
 
-if [ -L "kraken_bridge.xcframework" ]; then
-  ROOT=$(pwd)
-  rm kraken_bridge.xcframework
-  ln -s $ROOT/../../bridge/build/ios/framework/kraken_bridge.xcframework
+if [ -L "webf_bridge.xcframework" ]; then
+  rm webf_bridge.xcframework
+  ln -s $ROOT/../../../bridge/build/ios/framework/webf_bridge.xcframework
 fi
 
 if [ -L "quickjs.xcframework" ]; then
-  ROOT=$(pwd)
   rm quickjs.xcframework
-  ln -s $ROOT/../../bridge/build/ios/framework/quickjs.xcframework
+  ln -s $ROOT/../../../bridge/build/ios/framework/quickjs.xcframework
 fi

--- a/webf/ios/quickjs.xcframework
+++ b/webf/ios/quickjs.xcframework
@@ -1,1 +1,0 @@
-../../bridge/build/ios/framework/quickjs.xcframework

--- a/webf/ios/webf.podspec
+++ b/webf/ios/webf.podspec
@@ -16,8 +16,9 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
-  s.vendored_frameworks = 'webf_bridge.xcframework', 'quickjs.xcframework'
   s.prepare_command = 'bash prepare.sh'
+  s.vendored_frameworks = 'Frameworks/*.xcframework'
+  s.resource = 'Frameworks/*.*'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/webf/ios/webf_bridge.xcframework
+++ b/webf/ios/webf_bridge.xcframework
@@ -1,1 +1,0 @@
-../../bridge/build/ios/framework/webf_bridge.xcframework


### PR DESCRIPTION
Fix webf_bridge.xcframework and quickjs.xcframework missing when running `flutter build ios-framwork` command.