### PR TITLE
fix: should alway run npm install for codegen project

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -18,7 +18,7 @@ else ()
 endif ()
 
 execute_process(
-  COMMAND bash "-c" "if [ ! -d \"node_modules\" ]; then npm install; fi"
+  COMMAND bash "-c" "npm install"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts/code_generator
 ) # install code_generator deps
 


### PR DESCRIPTION
Always to run `npm install` for codegen project whether `node_modules` folder exists or not.