### PR TITLE
Fix/multiple context crash

### DIFF
--- a/.github/workflows/integration_test_flutter.yml
+++ b/.github/workflows/integration_test_flutter.yml
@@ -122,3 +122,27 @@ jobs:
     - name: Check on failures
       if: steps.test.outcome != 'success'
       run: exit 1
+  multiple_page_test:
+    runs-on: macos-12
+    needs: [ build_bridge ]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.nodeVersion }}
+    - uses: actions/download-artifact@v2
+      with:
+        name: macos_bridge_binary
+        path: bridge/build/macos/
+    - uses: subosito/flutter-action@v2
+      with:
+        flutter-version: ${{ env.flutterVersion }}
+    - run: flutter config --enable-macos-desktop
+    - run: flutter doctor -v
+    - name: Run MultiplePageTest Test
+      run: cd integration_tests && npm run multiple_page_test
+      id: test
+      continue-on-error: true
+    - name: Check on failures
+      if: steps.test.outcome != 'success'
+      run: exit 1

--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -18,7 +18,7 @@ else ()
 endif ()
 
 execute_process(
-  COMMAND bash "-c" "if [ ! -d \"node_modules\" ]; then npm install; fi"
+  COMMAND bash "-c" "npm install"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts/code_generator
 ) # install code_generator deps
 

--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -18,7 +18,7 @@ else ()
 endif ()
 
 execute_process(
-  COMMAND bash "-c" "npm install"
+  COMMAND bash "-c" "if [ ! -d \"node_modules\" ]; then npm install; fi"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts/code_generator
 ) # install code_generator deps
 

--- a/bridge/bindings/qjs/atomic_string.cc
+++ b/bridge/bindings/qjs/atomic_string.cc
@@ -68,21 +68,18 @@ AtomicString::StringKind GetStringKind(const NativeString* native_string) {
 
 AtomicString::AtomicString(JSContext* ctx, const std::string& string)
     : runtime_(JS_GetRuntime(ctx)),
-      ctx_(ctx),
       atom_(JS_NewAtom(ctx, string.c_str())),
       kind_(GetStringKind(string)),
       length_(string.size()) {}
 
 AtomicString::AtomicString(JSContext* ctx, const NativeString* native_string)
     : runtime_(JS_GetRuntime(ctx)),
-      ctx_(ctx),
       atom_(JS_NewUnicodeAtom(ctx, native_string->string(), native_string->length())),
       kind_(GetStringKind(native_string)),
       length_(native_string->length()) {}
 
 AtomicString::AtomicString(JSContext* ctx, JSValue value)
     : runtime_(JS_GetRuntime(ctx)),
-      ctx_(ctx),
       atom_(JS_IsNull(value) ? built_in_string::kempty_string.atom_ : JS_ValueToAtom(ctx, value)) {
   if (JS_IsString(value)) {
     kind_ = GetStringKind(value);
@@ -91,7 +88,7 @@ AtomicString::AtomicString(JSContext* ctx, JSValue value)
 }
 
 AtomicString::AtomicString(JSContext* ctx, JSAtom atom)
-    : runtime_(JS_GetRuntime(ctx)), ctx_(ctx), atom_(JS_DupAtom(ctx, atom)) {
+    : runtime_(JS_GetRuntime(ctx)), atom_(JS_DupAtom(ctx, atom)) {
   JSValue string = JS_AtomToValue(ctx, atom);
   kind_ = GetStringKind(string);
   length_ = JS_VALUE_GET_STRING(string)->len;
@@ -102,37 +99,32 @@ bool AtomicString::IsEmpty() const {
   return *this == built_in_string::kempty_string;
 }
 
-std::string AtomicString::ToStdString() const {
+std::string AtomicString::ToStdString(JSContext* ctx) const {
   if (IsEmpty())
     return "";
 
-  const char* buf = JS_AtomToCString(ctx_, atom_);
+  const char* buf = JS_AtomToCString(ctx, atom_);
   std::string result = std::string(buf);
-  JS_FreeCString(ctx_, buf);
+  JS_FreeCString(ctx, buf);
   return result;
 }
 
-std::unique_ptr<NativeString> AtomicString::ToNativeString() const {
-  JSValue stringValue = JS_AtomToValue(ctx_, atom_);
+std::unique_ptr<NativeString> AtomicString::ToNativeString(JSContext* ctx) const {
+  JSValue stringValue = JS_AtomToValue(ctx, atom_);
   uint32_t length;
-  uint16_t* bytes = JS_ToUnicode(ctx_, stringValue, &length);
-  JS_FreeValue(ctx_, stringValue);
+  uint16_t* bytes = JS_ToUnicode(ctx, stringValue, &length);
+  JS_FreeValue(ctx, stringValue);
   return std::make_unique<NativeString>(bytes, length);
 }
 
 StringView AtomicString::ToStringView() const {
-  JSValue stringValue = JS_AtomToValue(ctx_, atom_);
-  JSString* string = JS_VALUE_GET_STRING(stringValue);
-  assert(string->header.ref_count > 1);
-  JS_FreeValue(ctx_, stringValue);
-  return StringView(string->u.str8, string->len, string->is_wide_char);
+  return JSAtomToStringView(runtime_, atom_);
 }
 
 AtomicString::AtomicString(const AtomicString& value) {
   if (&value != this) {
-    atom_ = JS_DupAtom(value.ctx_, value.atom_);
+    atom_ = JS_DupAtomRT(value.runtime_, value.atom_);
   }
-  ctx_ = value.ctx_;
   runtime_ = value.runtime_;
   length_ = value.length_;
   kind_ = value.kind_;
@@ -140,11 +132,10 @@ AtomicString::AtomicString(const AtomicString& value) {
 
 AtomicString& AtomicString::operator=(const AtomicString& other) {
   if (&other != this) {
-    JS_FreeAtom(other.ctx_, atom_);
-    atom_ = JS_DupAtom(other.ctx_, other.atom_);
+    JS_FreeAtomRT(other.runtime_, atom_);
+    atom_ = JS_DupAtomRT(other.runtime_, other.atom_);
   }
   runtime_ = other.runtime_;
-  ctx_ = other.ctx_;
   length_ = other.length_;
   kind_ = other.kind_;
   return *this;
@@ -152,9 +143,8 @@ AtomicString& AtomicString::operator=(const AtomicString& other) {
 
 AtomicString::AtomicString(AtomicString&& value) noexcept {
   if (&value != this) {
-    atom_ = JS_DupAtom(value.ctx_, value.atom_);
+    atom_ = JS_DupAtomRT(value.runtime_, value.atom_);
   }
-  ctx_ = value.ctx_;
   runtime_ = value.runtime_;
   length_ = value.length_;
   kind_ = value.kind_;
@@ -162,51 +152,50 @@ AtomicString::AtomicString(AtomicString&& value) noexcept {
 
 AtomicString& AtomicString::operator=(AtomicString&& value) noexcept {
   if (&value != this) {
-    atom_ = JS_DupAtom(value.ctx_, value.atom_);
+    atom_ = JS_DupAtomRT(value.runtime_, value.atom_);
   }
-  ctx_ = value.ctx_;
   runtime_ = value.runtime_;
   length_ = value.length_;
   kind_ = value.kind_;
   return *this;
 }
 
-AtomicString AtomicString::ToUpperIfNecessary() const {
+AtomicString AtomicString::ToUpperIfNecessary(JSContext* ctx) const {
   if (kind_ == StringKind::kIsUpperCase) {
     return *this;
   }
   if (atom_upper_ != JS_ATOM_empty_string)
     return *this;
-  AtomicString upperString = ToUpperSlow();
+  AtomicString upperString = ToUpperSlow(ctx);
   atom_upper_ = upperString.atom_;
   return upperString;
 }
 
-const AtomicString AtomicString::ToUpperSlow() const {
-  const char* cptr = JS_AtomToCString(ctx_, atom_);
+const AtomicString AtomicString::ToUpperSlow(JSContext* ctx) const {
+  const char* cptr = JS_AtomToCString(ctx, atom_);
   std::string str = std::string(cptr);
   std::transform(str.begin(), str.end(), str.begin(), toupper);
-  JS_FreeCString(ctx_, cptr);
-  return AtomicString(ctx_, str);
+  JS_FreeCString(ctx, cptr);
+  return AtomicString(ctx, str);
 }
 
-const AtomicString AtomicString::ToLowerIfNecessary() const {
+const AtomicString AtomicString::ToLowerIfNecessary(JSContext* ctx) const {
   if (kind_ == StringKind::kIsLowerCase) {
     return *this;
   }
   if (atom_lower_ != JS_ATOM_empty_string)
     return *this;
-  AtomicString lowerString = ToLowerSlow();
+  AtomicString lowerString = ToLowerSlow(ctx);
   atom_lower_ = lowerString.atom_;
   return lowerString;
 }
 
-const AtomicString AtomicString::ToLowerSlow() const {
-  const char* cptr = JS_AtomToCString(ctx_, atom_);
+const AtomicString AtomicString::ToLowerSlow(JSContext* ctx) const {
+  const char* cptr = JS_AtomToCString(ctx, atom_);
   std::string str = std::string(cptr);
   std::transform(str.begin(), str.end(), str.begin(), tolower);
-  JS_FreeCString(ctx_, cptr);
-  return AtomicString(ctx_, str);
+  JS_FreeCString(ctx, cptr);
+  return AtomicString(ctx, str);
 }
 
 }  // namespace webf

--- a/bridge/bindings/qjs/atomic_string.cc
+++ b/bridge/bindings/qjs/atomic_string.cc
@@ -87,8 +87,7 @@ AtomicString::AtomicString(JSContext* ctx, JSValue value)
   }
 }
 
-AtomicString::AtomicString(JSContext* ctx, JSAtom atom)
-    : runtime_(JS_GetRuntime(ctx)), atom_(JS_DupAtom(ctx, atom)) {
+AtomicString::AtomicString(JSContext* ctx, JSAtom atom) : runtime_(JS_GetRuntime(ctx)), atom_(JS_DupAtom(ctx, atom)) {
   JSValue string = JS_AtomToValue(ctx, atom);
   kind_ = GetStringKind(string);
   length_ = JS_VALUE_GET_STRING(string)->len;

--- a/bridge/bindings/qjs/atomic_string.h
+++ b/bridge/bindings/qjs/atomic_string.h
@@ -44,11 +44,11 @@ class AtomicString {
 
   // Return the undefined string value from atom key.
   JSValue ToQuickJS(JSContext* ctx) const {
-    if (ctx_ == nullptr) {
+    if (ctx == nullptr) {
       return JS_NULL;
     }
 
-    assert(ctx_ != nullptr);
+    assert(ctx != nullptr);
     return JS_AtomToValue(ctx, atom_);
   };
 
@@ -58,16 +58,16 @@ class AtomicString {
 
   int64_t length() const { return length_; }
 
-  [[nodiscard]] std::string ToStdString() const;
-  [[nodiscard]] std::unique_ptr<NativeString> ToNativeString() const;
+  [[nodiscard]] std::string ToStdString(JSContext* ctx) const;
+  [[nodiscard]] std::unique_ptr<NativeString> ToNativeString(JSContext* ctx) const;
 
   StringView ToStringView() const;
 
-  AtomicString ToUpperIfNecessary() const;
-  const AtomicString ToUpperSlow() const;
+  AtomicString ToUpperIfNecessary(JSContext* ctx) const;
+  const AtomicString ToUpperSlow(JSContext* ctx) const;
 
-  const AtomicString ToLowerIfNecessary() const;
-  const AtomicString ToLowerSlow() const;
+  const AtomicString ToLowerIfNecessary(JSContext* ctx) const;
+  const AtomicString ToLowerSlow(JSContext* ctx) const;
 
   // Copy assignment
   AtomicString(AtomicString const& value);
@@ -81,7 +81,6 @@ class AtomicString {
   bool operator!=(const AtomicString& other) const { return other.atom_ != this->atom_; };
 
  protected:
-  JSContext* ctx_{nullptr};
   JSRuntime* runtime_{nullptr};
   int64_t length_{0};
   JSAtom atom_{JS_ATOM_empty_string};

--- a/bridge/bindings/qjs/atomic_string_test.cc
+++ b/bridge/bindings/qjs/atomic_string_test.cc
@@ -33,7 +33,7 @@ void TestAtomicString(TestCallback callback) {
 TEST(AtomicString, Empty) {
   TestAtomicString([](JSContext* ctx) {
     AtomicString atomic_string = AtomicString::Empty();
-    EXPECT_STREQ(atomic_string.ToStdString().c_str(), "");
+    EXPECT_STREQ(atomic_string.ToStdString(ctx).c_str(), "");
   });
 }
 
@@ -42,14 +42,14 @@ TEST(AtomicString, FromNativeString) {
     auto nativeString = stringToNativeString("helloworld");
     AtomicString value = AtomicString::From(ctx, nativeString.get());
 
-    EXPECT_STREQ(value.ToStdString().c_str(), "helloworld");
+    EXPECT_STREQ(value.ToStdString(ctx).c_str(), "helloworld");
   });
 }
 
 TEST(AtomicString, CreateFromStdString) {
   TestAtomicString([](JSContext* ctx) {
     AtomicString&& value = AtomicString(ctx, "helloworld");
-    EXPECT_STREQ(value.ToStdString().c_str(), "helloworld");
+    EXPECT_STREQ(value.ToStdString(ctx).c_str(), "helloworld");
   });
 }
 
@@ -57,7 +57,7 @@ TEST(AtomicString, CreateFromJSValue) {
   TestAtomicString([](JSContext* ctx) {
     JSValue string = JS_NewString(ctx, "helloworld");
     AtomicString&& value = AtomicString(ctx, string);
-    EXPECT_STREQ(value.ToStdString().c_str(), "helloworld");
+    EXPECT_STREQ(value.ToStdString(ctx).c_str(), "helloworld");
     JS_FreeValue(ctx, string);
   });
 }
@@ -76,7 +76,7 @@ TEST(AtomicString, ToQuickJS) {
 TEST(AtomicString, ToNativeString) {
   TestAtomicString([](JSContext* ctx) {
     AtomicString&& value = AtomicString(ctx, "helloworld");
-    auto native_string = value.ToNativeString();
+    auto native_string = value.ToNativeString(ctx);
     const uint16_t* p = native_string->string();
     EXPECT_EQ(native_string->length(), 10);
 
@@ -103,7 +103,7 @@ TEST(AtomicString, MoveAssignment) {
   TestAtomicString([](JSContext* ctx) {
     auto&& str = AtomicString(ctx, "helloworld");
     auto&& str2 = AtomicString(std::move(str));
-    EXPECT_STREQ(str2.ToStdString().c_str(), "helloworld");
+    EXPECT_STREQ(str2.ToStdString(ctx).c_str(), "helloworld");
   });
 }
 
@@ -113,6 +113,6 @@ TEST(AtomicString, CopyToRightReference) {
     if (1 + 1 == 2) {
       str = AtomicString(ctx, "helloworld");
     }
-    EXPECT_STREQ(str.ToStdString().c_str(), "helloworld");
+    EXPECT_STREQ(str.ToStdString(ctx).c_str(), "helloworld");
   });
 }

--- a/bridge/bindings/qjs/qjs_engine_patch.cc
+++ b/bridge/bindings/qjs/qjs_engine_patch.cc
@@ -359,3 +359,8 @@ JSValue JS_GetProxyTarget(JSValue value) {
 JSGCPhaseEnum JS_GetEnginePhase(JSRuntime* runtime) {
   return runtime->gc_phase;
 }
+
+webf::StringView JSAtomToStringView(JSRuntime* runtime, JSAtom atom) {
+  JSString* string = runtime->atom_array[atom];
+  return webf::StringView(string->u.str8, string->len, string->is_wide_char);
+}

--- a/bridge/bindings/qjs/qjs_engine_patch.h
+++ b/bridge/bindings/qjs/qjs_engine_patch.h
@@ -8,6 +8,7 @@
 
 #include <quickjs/list.h>
 #include <quickjs/quickjs.h>
+#include "foundation/string_view.h"
 
 struct JSString {
   JSRefCountHeader header; /* must come first, 32-bit */
@@ -124,6 +125,7 @@ bool JS_IsArrayBufferView(JSValue value);
 bool JS_HasClassId(JSRuntime* runtime, JSClassID classId);
 JSValue JS_GetProxyTarget(JSValue value);
 JSGCPhaseEnum JS_GetEnginePhase(JSRuntime* runtime);
+webf::StringView JSAtomToStringView(JSRuntime* runtime, JSAtom atom);
 
 static inline bool JS_AtomIsTaggedInt(JSAtom v) {
   return (v & JS_ATOM_TAG_INT) != 0;

--- a/bridge/bindings/qjs/script_value.cc
+++ b/bridge/bindings/qjs/script_value.cc
@@ -147,6 +147,10 @@ AtomicString ScriptValue::ToString() const {
   return {ctx_, value_};
 }
 
+std::unique_ptr<NativeString> ScriptValue::ToNativeString() const {
+  return ToString().ToNativeString(ctx_);
+}
+
 NativeValue ScriptValue::ToNative(ExceptionState& exception_state) const {
   int8_t tag = JS_VALUE_GET_TAG(value_);
 
@@ -168,7 +172,7 @@ NativeValue ScriptValue::ToNative(ExceptionState& exception_state) const {
     }
     case JS_TAG_STRING:
       // NativeString owned by NativeValue will be freed by users.
-      return NativeValueConverter<NativeTypeString>::ToNativeValue(ToString());
+      return NativeValueConverter<NativeTypeString>::ToNativeValue(ctx_, ToString());
     case JS_TAG_OBJECT: {
       if (JS_IsArray(ctx_, value_)) {
         std::vector<ScriptValue> values =

--- a/bridge/bindings/qjs/script_value.h
+++ b/bridge/bindings/qjs/script_value.h
@@ -60,6 +60,7 @@ class ScriptValue final {
   // Create a new ScriptValue from call JSON.stringify to current value.
   ScriptValue ToJSONStringify(ExceptionState* exception) const;
   AtomicString ToString() const;
+  std::unique_ptr<NativeString> ToNativeString() const;
   NativeValue ToNative(ExceptionState& exception_state) const;
 
   bool IsException() const;

--- a/bridge/bindings/qjs/script_value_test.cc
+++ b/bridge/bindings/qjs/script_value_test.cc
@@ -50,7 +50,7 @@ TEST(ScriptValue, ToString) {
     std::string code = "{\"name\": 1}";
     ScriptValue json = ScriptValue::CreateJsonObject(ctx, code.c_str(), code.size());
     AtomicString string = json.ToString();
-    EXPECT_STREQ(string.ToStdString().c_str(), "[object Object]");
+    EXPECT_STREQ(string.ToStdString(ctx).c_str(), "[object Object]");
   });
 }
 
@@ -63,7 +63,7 @@ TEST(ScriptValue, CopyAssignment) {
     };
     P p;
     p.value = json;
-    EXPECT_STREQ(p.value.ToJSONStringify(nullptr).ToString().ToStdString().c_str(), code.c_str());
+    EXPECT_STREQ(p.value.ToJSONStringify(nullptr).ToString().ToStdString(ctx).c_str(), code.c_str());
   });
 }
 
@@ -75,6 +75,6 @@ TEST(ScriptValue, MoveAssignment) {
       other = ScriptValue::CreateJsonObject(ctx, code.c_str(), code.size());
     }
 
-    EXPECT_STREQ(other.ToJSONStringify(nullptr).ToString().ToStdString().c_str(), "{\"name\":1}");
+    EXPECT_STREQ(other.ToJSONStringify(nullptr).ToString().ToStdString(ctx).c_str(), "{\"name\":1}");
   });
 }

--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -59,7 +59,7 @@ NativeValue BindingObject::InvokeBindingMethod(const AtomicString& method,
   }
 
   NativeValue return_value = Native_NewNull();
-  NativeValue native_method = NativeValueConverter<NativeTypeString>::ToNativeValue(method);
+  NativeValue native_method = NativeValueConverter<NativeTypeString>::ToNativeValue(context_->ctx(), method);
   binding_object_->invoke_bindings_methods_from_native(binding_object_, &return_value, &native_method, argc, argv);
   return return_value;
 }
@@ -83,7 +83,7 @@ NativeValue BindingObject::InvokeBindingMethod(BindingMethodCallOperations bindi
 
 NativeValue BindingObject::GetBindingProperty(const AtomicString& prop, ExceptionState& exception_state) const {
   context_->FlushUICommand();
-  const NativeValue argv[] = {Native_NewString(prop.ToNativeString().release())};
+  const NativeValue argv[] = {Native_NewString(prop.ToNativeString(context_->ctx()).release())};
   return InvokeBindingMethod(BindingMethodCallOperations::kGetProperty, 1, argv, exception_state);
 }
 
@@ -91,7 +91,7 @@ NativeValue BindingObject::SetBindingProperty(const AtomicString& prop,
                                               NativeValue value,
                                               ExceptionState& exception_state) const {
   context_->FlushUICommand();
-  const NativeValue argv[] = {Native_NewString(prop.ToNativeString().release()), value};
+  const NativeValue argv[] = {Native_NewString(prop.ToNativeString(context_->ctx()).release()), value};
   return InvokeBindingMethod(BindingMethodCallOperations::kSetProperty, 2, argv, exception_state);
 }
 

--- a/bridge/core/css/legacy/css_style_declaration.cc
+++ b/bridge/core/css/legacy/css_style_declaration.cc
@@ -59,12 +59,12 @@ CSSStyleDeclaration::CSSStyleDeclaration(ExecutingContext* context, int64_t owne
     : ScriptWrappable(context->ctx()), owner_element_target_id_(owner_element_target_id) {}
 
 AtomicString CSSStyleDeclaration::item(const AtomicString& key, ExceptionState& exception_state) {
-  std::string propertyName = key.ToStdString();
+  std::string propertyName = key.ToStdString(ctx());
   return InternalGetPropertyValue(propertyName);
 }
 
 bool CSSStyleDeclaration::SetItem(const AtomicString& key, const AtomicString& value, ExceptionState& exception_state) {
-  std::string propertyName = key.ToStdString();
+  std::string propertyName = key.ToStdString(ctx());
   return InternalSetProperty(propertyName, value);
 }
 
@@ -73,19 +73,19 @@ int64_t CSSStyleDeclaration::length() const {
 }
 
 AtomicString CSSStyleDeclaration::getPropertyValue(const AtomicString& key, ExceptionState& exception_state) {
-  std::string propertyName = key.ToStdString();
+  std::string propertyName = key.ToStdString(ctx());
   return InternalGetPropertyValue(propertyName);
 }
 
 void CSSStyleDeclaration::setProperty(const AtomicString& key,
                                       const AtomicString& value,
                                       ExceptionState& exception_state) {
-  std::string propertyName = key.ToStdString();
+  std::string propertyName = key.ToStdString(ctx());
   InternalSetProperty(propertyName, value);
 }
 
 AtomicString CSSStyleDeclaration::removeProperty(const AtomicString& key, ExceptionState& exception_state) {
-  std::string propertyName = key.ToStdString();
+  std::string propertyName = key.ToStdString(ctx());
   return InternalRemoveProperty(propertyName);
 }
 
@@ -102,7 +102,7 @@ std::string CSSStyleDeclaration::ToString() const {
   std::string s;
 
   for (auto& attr : properties_) {
-    s += attr.first + ": " + attr.second.ToStdString() + ";";
+    s += attr.first + ": " + attr.second.ToStdString(ctx()) + ";";
   }
 
   s += "\"";
@@ -110,7 +110,7 @@ std::string CSSStyleDeclaration::ToString() const {
 }
 
 bool CSSStyleDeclaration::NamedPropertyQuery(const AtomicString& key, ExceptionState&) {
-  return cssPropertyList.count(key.ToStdString()) > 0;
+  return cssPropertyList.count(key.ToStdString(ctx())) > 0;
 }
 
 void CSSStyleDeclaration::NamedPropertyEnumerator(std::vector<AtomicString>& names, ExceptionState&) {
@@ -139,7 +139,7 @@ bool CSSStyleDeclaration::InternalSetProperty(std::string& name, const AtomicStr
   properties_[name] = value;
 
   std::unique_ptr<NativeString> args_01 = stringToNativeString(name);
-  std::unique_ptr<NativeString> args_02 = value.ToNativeString();
+  std::unique_ptr<NativeString> args_02 = value.ToNativeString(ctx());
   GetExecutingContext()->uiCommandBuffer()->addCommand(owner_element_target_id_, UICommand::kSetStyle,
                                                        std::move(args_01), std::move(args_02), nullptr);
 

--- a/bridge/core/dom/character_data.cc
+++ b/bridge/core/dom/character_data.cc
@@ -14,14 +14,14 @@ void CharacterData::setData(const AtomicString& data, ExceptionState& exception_
   data_ = data;
 
   std::unique_ptr<NativeString> args_01 = stringToNativeString("data");
-  std::unique_ptr<NativeString> args_02 = data.ToNativeString();
+  std::unique_ptr<NativeString> args_02 = data.ToNativeString(ctx());
 
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kSetAttribute, std::move(args_01),
                                                        std::move(args_02), (void*)bindingObject());
 }
 
 std::string CharacterData::nodeValue() const {
-  return data_.ToStdString();
+  return data_.ToStdString(ctx());
 }
 
 bool CharacterData::IsCharacterDataNode() const {

--- a/bridge/core/dom/child_node_list.cc
+++ b/bridge/core/dom/child_node_list.cc
@@ -20,7 +20,7 @@ Node* ChildNodeList::item(unsigned index, ExceptionState& exception_state) const
 }
 
 bool ChildNodeList::NamedPropertyQuery(const AtomicString& key, ExceptionState& exception_state) {
-  int32_t index = std::stoi(key.ToStdString());
+  int32_t index = std::stoi(key.ToStdString(ctx()));
   return collection_index_cache_.NodeAt(*this, index);
 }
 

--- a/bridge/core/dom/document.cc
+++ b/bridge/core/dom/document.cc
@@ -40,7 +40,7 @@ Document::Document(ExecutingContext* context)
 Element* Document::createElement(const AtomicString& name, ExceptionState& exception_state) {
   if (!IsValidName(name)) {
     exception_state.ThrowException(ctx(), ErrorType::InternalError,
-                                   "The tag name provided ('" + name.ToStdString() + "') is not a valid name.");
+                                   "The tag name provided ('" + name.ToStdString(ctx()) + "') is not a valid name.");
     return nullptr;
   }
 
@@ -120,7 +120,7 @@ bool Document::ChildTypeAllowed(NodeType type) const {
 }
 
 Element* Document::querySelector(const AtomicString& selectors, ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(selectors)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), selectors)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kquerySelector, 1, arguments, exception_state);
   if (exception_state.HasException()) {
     return nullptr;
@@ -129,7 +129,7 @@ Element* Document::querySelector(const AtomicString& selectors, ExceptionState& 
 }
 
 std::vector<Element*> Document::querySelectorAll(const AtomicString& selectors, ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(selectors)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), selectors)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kquerySelectorAll, 1, arguments, exception_state);
   if (exception_state.HasException()) {
     return {};
@@ -138,7 +138,7 @@ std::vector<Element*> Document::querySelectorAll(const AtomicString& selectors, 
 }
 
 Element* Document::getElementById(const AtomicString& id, ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(id)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), id)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kgetElementById, 1, arguments, exception_state);
   if (exception_state.HasException()) {
     return {};
@@ -148,7 +148,7 @@ Element* Document::getElementById(const AtomicString& id, ExceptionState& except
 
 std::vector<Element*> Document::getElementsByClassName(const AtomicString& class_name,
                                                        ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(class_name)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), class_name)};
   NativeValue result =
       InvokeBindingMethod(binding_call_methods::kgetElementsByClassName, 1, arguments, exception_state);
   if (exception_state.HasException()) {
@@ -158,7 +158,7 @@ std::vector<Element*> Document::getElementsByClassName(const AtomicString& class
 }
 
 std::vector<Element*> Document::getElementsByTagName(const AtomicString& tag_name, ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(tag_name)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), tag_name)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kgetElementsByTagName, 1, arguments, exception_state);
   if (exception_state.HasException()) {
     return {};
@@ -167,7 +167,7 @@ std::vector<Element*> Document::getElementsByTagName(const AtomicString& tag_nam
 }
 
 std::vector<Element*> Document::getElementsByName(const AtomicString& name, ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(name)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), name)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kgetElementsByName, 1, arguments, exception_state);
   if (exception_state.HasException()) {
     return {};
@@ -263,7 +263,7 @@ void Document::setBody(HTMLBodyElement* new_body, ExceptionState& exception_stat
 
   if (!IsA<HTMLBodyElement>(*new_body)) {
     exception_state.ThrowException(ctx(), ErrorType::TypeError,
-                                   "The new body element is of type '" + new_body->tagName().ToStdString() +
+                                   "The new body element is of type '" + new_body->tagName().ToStdString(ctx()) +
                                        "'. It must be either a 'BODY' element.");
     return;
   }

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -22,8 +22,8 @@ namespace webf {
 
 Element::Element(const AtomicString& tag_name, Document* document, Node::ConstructionType construction_type)
     : ContainerNode(document, construction_type), tag_name_(tag_name) {
-  GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kCreateElement,
-                                                       std::move(tag_name.ToNativeString(ctx())), (void*)bindingObject());
+  GetExecutingContext()->uiCommandBuffer()->addCommand(
+      eventTargetId(), UICommand::kCreateElement, std::move(tag_name.ToNativeString(ctx())), (void*)bindingObject());
 }
 
 ElementAttributes& Element::EnsureElementAttributes() {

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -23,7 +23,7 @@ namespace webf {
 Element::Element(const AtomicString& tag_name, Document* document, Node::ConstructionType construction_type)
     : ContainerNode(document, construction_type), tag_name_(tag_name) {
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kCreateElement,
-                                                       std::move(tag_name.ToNativeString()), (void*)bindingObject());
+                                                       std::move(tag_name.ToNativeString(ctx())), (void*)bindingObject());
 }
 
 ElementAttributes& Element::EnsureElementAttributes() {
@@ -142,15 +142,15 @@ std::string Element::nodeValue() const {
 }
 
 std::string Element::nodeName() const {
-  return tag_name_.ToUpperIfNecessary().ToStdString();
+  return tag_name_.ToUpperIfNecessary(ctx()).ToStdString(ctx());
 }
 
 std::string Element::nodeNameLowerCase() const {
-  return tag_name_.ToStdString();
+  return tag_name_.ToStdString(ctx());
 }
 
 std::vector<Element*> Element::getElementsByClassName(const AtomicString& class_name, ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(class_name)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), class_name)};
   NativeValue result =
       InvokeBindingMethod(binding_call_methods::kgetElementsByClassName, 1, arguments, exception_state);
   if (exception_state.HasException()) {
@@ -160,7 +160,7 @@ std::vector<Element*> Element::getElementsByClassName(const AtomicString& class_
 }
 
 std::vector<Element*> Element::getElementsByTagName(const AtomicString& tag_name, ExceptionState& exception_state) {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(tag_name)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), tag_name)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kgetElementsByTagName, 1, arguments, exception_state);
   if (exception_state.HasException()) {
     return {};
@@ -357,7 +357,7 @@ std::string Element::innerHTML() {
     if (auto* element = DynamicTo<Element>(child)) {
       s += element->outerHTML();
     } else if (auto* text = DynamicTo<Text>(child)) {
-      s += text->data().ToStdString();
+      s += text->data().ToStdString(ctx());
     }
     child = child->nextSibling();
   }
@@ -366,7 +366,7 @@ std::string Element::innerHTML() {
 }
 
 void Element::setInnerHTML(const AtomicString& value, ExceptionState& exception_state) {
-  auto html = value.ToStdString();
+  auto html = value.ToStdString(ctx());
   if (auto* template_element = DynamicTo<HTMLTemplateElement>(this)) {
     HTMLParser::parseHTMLFragment(html.c_str(), html.size(), template_element->content());
   } else {

--- a/bridge/core/dom/element.h
+++ b/bridge/core/dom/element.h
@@ -56,7 +56,7 @@ class Element : public ContainerNode {
 
   bool HasTagName(const AtomicString&) const;
   std::string nodeValue() const override;
-  AtomicString tagName() const { return tag_name_.ToUpperSlow(); }
+  AtomicString tagName() const { return tag_name_.ToUpperSlow(ctx()); }
   std::string nodeName() const override;
   std::string nodeNameLowerCase() const;
 

--- a/bridge/core/dom/events/event_target.cc
+++ b/bridge/core/dom/events/event_target.cc
@@ -218,7 +218,7 @@ bool EventTarget::AddEventListenerInternal(const AtomicString& event_type,
 
   if (added && listener_count == 1) {
     GetExecutingContext()->uiCommandBuffer()->addCommand(event_target_id_, UICommand::kAddEvent,
-                                                         std::move(event_type.ToNativeString()), nullptr);
+                                                         std::move(event_type.ToNativeString(ctx())), nullptr);
   }
 
   return added;
@@ -264,7 +264,7 @@ bool EventTarget::RemoveEventListenerInternal(const AtomicString& event_type,
 
   if (listener_count == 0) {
     GetExecutingContext()->uiCommandBuffer()->addCommand(event_target_id_, UICommand::kRemoveEvent,
-                                                         std::move(event_type.ToNativeString()), nullptr);
+                                                         std::move(event_type.ToNativeString(ctx())), nullptr);
   }
 
   return true;

--- a/bridge/core/dom/legacy/element_attributes.cc
+++ b/bridge/core/dom/legacy/element_attributes.cc
@@ -48,14 +48,14 @@ bool ElementAttributes::setAttribute(const AtomicString& name,
   if (numberIndex) {
     exception_state.ThrowException(
         ctx(), ErrorType::TypeError,
-        "Failed to execute 'kSetAttribute' on 'Element': '" + name.ToStdString() + "' is not a valid attribute name.");
+        "Failed to execute 'kSetAttribute' on 'Element': '" + name.ToStdString(ctx()) + "' is not a valid attribute name.");
     return false;
   }
 
   attributes_[name] = value;
 
-  std::unique_ptr<NativeString> args_01 = name.ToNativeString();
-  std::unique_ptr<NativeString> args_02 = value.ToNativeString();
+  std::unique_ptr<NativeString> args_01 = name.ToNativeString(ctx());
+  std::unique_ptr<NativeString> args_02 = value.ToNativeString(ctx());
 
   GetExecutingContext()->uiCommandBuffer()->addCommand(element_->eventTargetId(), UICommand::kSetAttribute,
                                                        std::move(args_01), std::move(args_02), nullptr);
@@ -76,7 +76,7 @@ bool ElementAttributes::hasAttribute(const AtomicString& name, ExceptionState& e
 void ElementAttributes::removeAttribute(const AtomicString& name, ExceptionState& exception_state) {
   attributes_.erase(name);
 
-  std::unique_ptr<NativeString> args_01 = name.ToNativeString();
+  std::unique_ptr<NativeString> args_01 = name.ToNativeString(ctx());
   GetExecutingContext()->uiCommandBuffer()->addCommand(element_->eventTargetId(), UICommand::kRemoveAttribute,
                                                        std::move(args_01), nullptr);
 }
@@ -91,8 +91,8 @@ std::string ElementAttributes::ToString() {
   std::string s;
 
   for (auto& attr : attributes_) {
-    s += attr.first.ToStdString() + "=";
-    s += "\"" + attr.second.ToStdString() + "\"";
+    s += attr.first.ToStdString(ctx()) + "=";
+    s += "\"" + attr.second.ToStdString(ctx()) + "\"";
   }
 
   return s;

--- a/bridge/core/dom/legacy/element_attributes.cc
+++ b/bridge/core/dom/legacy/element_attributes.cc
@@ -46,9 +46,9 @@ bool ElementAttributes::setAttribute(const AtomicString& name,
   bool numberIndex = IsNumberIndex(name.ToStringView());
 
   if (numberIndex) {
-    exception_state.ThrowException(
-        ctx(), ErrorType::TypeError,
-        "Failed to execute 'kSetAttribute' on 'Element': '" + name.ToStdString(ctx()) + "' is not a valid attribute name.");
+    exception_state.ThrowException(ctx(), ErrorType::TypeError,
+                                   "Failed to execute 'kSetAttribute' on 'Element': '" + name.ToStdString(ctx()) +
+                                       "' is not a valid attribute name.");
     return false;
   }
 

--- a/bridge/core/dom/node.cc
+++ b/bridge/core/dom/node.cc
@@ -232,7 +232,7 @@ AtomicString Node::textContent(bool convert_brs_to_newlines) const {
   std::string content;
   for (const Node& node : NodeTraversal::InclusiveDescendantsOf(*this)) {
     if (auto* text_node = DynamicTo<Text>(node)) {
-      content.append(text_node->data().ToStdString());
+      content.append(text_node->data().ToStdString(ctx()));
     }
   }
   return AtomicString(ctx(), content);

--- a/bridge/core/dom/text.h
+++ b/bridge/core/dom/text.h
@@ -22,7 +22,7 @@ class Text : public CharacterData {
 
   Text(TreeScope& tree_scope, const AtomicString& data, ConstructionType type) : CharacterData(tree_scope, data, type) {
     GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kCreateTextNode,
-                                                         std::move(data.ToNativeString()), (void*)bindingObject());
+                                                         std::move(data.ToNativeString(ctx())), (void*)bindingObject());
   }
 
   NodeType nodeType() const override;

--- a/bridge/core/events/error_event.cc
+++ b/bridge/core/events/error_event.cc
@@ -30,7 +30,7 @@ ErrorEvent::ErrorEvent(ExecutingContext* context, const std::string& message, st
 
 ErrorEvent::ErrorEvent(ExecutingContext* context, const AtomicString& type, ExceptionState& exception_state)
     : Event(context, event_type_names::kerror),
-      message_(type.ToStdString()),
+      message_(type.ToStdString(ctx())),
       source_location_(std::make_unique<SourceLocation>("", 0, 0)) {}
 
 ErrorEvent::ErrorEvent(ExecutingContext* context,
@@ -38,10 +38,10 @@ ErrorEvent::ErrorEvent(ExecutingContext* context,
                        const std::shared_ptr<ErrorEventInit>& initializer,
                        ExceptionState& exception_state)
     : Event(context, event_type_names::kerror),
-      message_(initializer->hasMessage() ? type.ToStdString() : ""),
+      message_(initializer->hasMessage() ? type.ToStdString(ctx()) : ""),
       error_(initializer->hasError() ? initializer->error() : ScriptValue::Empty(ctx())),
       source_location_(
-          std::make_unique<SourceLocation>(initializer->hasFilename() ? initializer->filename().ToStdString() : "",
+          std::make_unique<SourceLocation>(initializer->hasFilename() ? initializer->filename().ToStdString(ctx()) : "",
                                            initializer->lineno(),
                                            initializer->colno())) {}
 

--- a/bridge/core/fileapi/blob.cc
+++ b/bridge/core/fileapi/blob.cc
@@ -91,7 +91,7 @@ Blob* Blob::slice(int64_t start, int64_t end, const AtomicString& content_type, 
   newData.reserve(_data.size() - (end - start));
   newData.insert(newData.begin(), _data.begin() + start, _data.end() - (_data.size() - end));
   newBlob->_data = newData;
-  newBlob->mime_type_ = content_type != built_in_string::kempty_string ? content_type.ToStdString() : mime_type_;
+  newBlob->mime_type_ = content_type != built_in_string::kempty_string ? content_type.ToStdString(ctx()) : mime_type_;
   return newBlob;
 }
 

--- a/bridge/core/frame/console.cc
+++ b/bridge/core/frame/console.cc
@@ -16,7 +16,8 @@ void Console::__webf_print__(ExecutingContext* context,
   std::stringstream stream;
   std::string buffer = log.ToStdString(context->ctx());
   stream << buffer;
-  printLog(context, stream, level != built_in_string::kempty_string ? level.ToStdString(context->ctx()) : "info", nullptr);
+  printLog(context, stream, level != built_in_string::kempty_string ? level.ToStdString(context->ctx()) : "info",
+           nullptr);
 }
 
 void Console::__webf_print__(ExecutingContext* context, const AtomicString& log, ExceptionState& exception_state) {

--- a/bridge/core/frame/console.cc
+++ b/bridge/core/frame/console.cc
@@ -14,14 +14,14 @@ void Console::__webf_print__(ExecutingContext* context,
                              const AtomicString& level,
                              ExceptionState& exception) {
   std::stringstream stream;
-  std::string buffer = log.ToStdString();
+  std::string buffer = log.ToStdString(context->ctx());
   stream << buffer;
-  printLog(context, stream, level != built_in_string::kempty_string ? level.ToStdString() : "info", nullptr);
+  printLog(context, stream, level != built_in_string::kempty_string ? level.ToStdString(context->ctx()) : "info", nullptr);
 }
 
 void Console::__webf_print__(ExecutingContext* context, const AtomicString& log, ExceptionState& exception_state) {
   std::stringstream stream;
-  std::string buffer = log.ToStdString();
+  std::string buffer = log.ToStdString(context->ctx());
   stream << buffer;
   printLog(context, stream, "info", nullptr);
 }

--- a/bridge/core/frame/module_manager.cc
+++ b/bridge/core/frame/module_manager.cc
@@ -119,11 +119,11 @@ ScriptValue ModuleManager::__webf_invoke_module__(ExecutingContext* context,
     auto module_context = std::make_shared<ModuleContext>(context, module_callback);
     context->ModuleContexts()->AddModuleContext(module_context);
     result = context->dartMethodPtr()->invokeModule(module_context.get(), context->contextId(),
-                                                    module_name.ToNativeString().get(), method.ToNativeString().get(),
+                                                    module_name.ToNativeString(context->ctx()).get(), method.ToNativeString(context->ctx()).get(),
                                                     &params, handleInvokeModuleTransientCallback);
   } else {
-    result = context->dartMethodPtr()->invokeModule(nullptr, context->contextId(), module_name.ToNativeString().get(),
-                                                    method.ToNativeString().get(), &params,
+    result = context->dartMethodPtr()->invokeModule(nullptr, context->contextId(), module_name.ToNativeString(context->ctx()).get(),
+                                                    method.ToNativeString(context->ctx()).get(), &params,
                                                     handleInvokeModuleUnexpectedCallback);
   }
 

--- a/bridge/core/frame/module_manager.cc
+++ b/bridge/core/frame/module_manager.cc
@@ -118,13 +118,13 @@ ScriptValue ModuleManager::__webf_invoke_module__(ExecutingContext* context,
     auto module_callback = ModuleCallback::Create(callback);
     auto module_context = std::make_shared<ModuleContext>(context, module_callback);
     context->ModuleContexts()->AddModuleContext(module_context);
-    result = context->dartMethodPtr()->invokeModule(module_context.get(), context->contextId(),
-                                                    module_name.ToNativeString(context->ctx()).get(), method.ToNativeString(context->ctx()).get(),
-                                                    &params, handleInvokeModuleTransientCallback);
+    result = context->dartMethodPtr()->invokeModule(
+        module_context.get(), context->contextId(), module_name.ToNativeString(context->ctx()).get(),
+        method.ToNativeString(context->ctx()).get(), &params, handleInvokeModuleTransientCallback);
   } else {
-    result = context->dartMethodPtr()->invokeModule(nullptr, context->contextId(), module_name.ToNativeString(context->ctx()).get(),
-                                                    method.ToNativeString(context->ctx()).get(), &params,
-                                                    handleInvokeModuleUnexpectedCallback);
+    result = context->dartMethodPtr()->invokeModule(
+        nullptr, context->contextId(), module_name.ToNativeString(context->ctx()).get(),
+        method.ToNativeString(context->ctx()).get(), &params, handleInvokeModuleUnexpectedCallback);
   }
 
   if (result == nullptr) {

--- a/bridge/core/frame/window.cc
+++ b/bridge/core/frame/window.cc
@@ -24,7 +24,7 @@ Window* Window::open(ExceptionState& exception_state) {
 
 Window* Window::open(const AtomicString& url, ExceptionState& exception_state) {
   const NativeValue args[] = {
-      NativeValueConverter<NativeTypeString>::ToNativeValue(url),
+      NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), url),
   };
   InvokeBindingMethod(binding_call_methods::kopen, 1, args, exception_state);
   return this;

--- a/bridge/core/html/canvas/html_canvas_element.cc
+++ b/bridge/core/html/canvas/html_canvas_element.cc
@@ -15,7 +15,7 @@ namespace webf {
 HTMLCanvasElement::HTMLCanvasElement(Document& document) : HTMLElement(html_names::kcanvas, &document) {}
 
 CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, ExceptionState& exception_state) const {
-  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(type)};
+  NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), type)};
   NativeValue value = InvokeBindingMethod(binding_call_methods::kgetContext, 1, arguments, exception_state);
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);

--- a/bridge/core/html/custom/widget_element.cc
+++ b/bridge/core/html/custom/widget_element.cc
@@ -60,7 +60,7 @@ ScriptValue WidgetElement::item(const AtomicString& key, ExceptionState& excepti
   }
 
   if (key == built_in_string::kSymbol_toStringTag) {
-    return ScriptValue(ctx(), tagName().ToNativeString().release());
+    return ScriptValue(ctx(), tagName().ToNativeString(ctx()).release());
   }
 
   return ScriptValue(ctx(), GetBindingProperty(key, exception_state));

--- a/bridge/core/html/legacy/html_collection.cc
+++ b/bridge/core/html/legacy/html_collection.cc
@@ -41,7 +41,7 @@ Element* HTMLCollection::item(unsigned int offset, ExceptionState& exception_sta
 }
 
 bool HTMLCollection::NamedPropertyQuery(const AtomicString& key, ExceptionState&) {
-  int32_t index = std::stoi(key.ToStdString());
+  int32_t index = std::stoi(key.ToStdString(ctx()));
   return index >= 0 && index < nodes_.size();
 }
 

--- a/bridge/core/input/touch_list.cc
+++ b/bridge/core/input/touch_list.cc
@@ -39,7 +39,7 @@ bool TouchList::SetItem(uint32_t index, Touch* touch, ExceptionState& exception_
 }
 
 bool TouchList::NamedPropertyQuery(const AtomicString& key, ExceptionState& exception_state) {
-  uint32_t index = std::stoi(key.ToStdString());
+  uint32_t index = std::stoi(key.ToStdString(ctx()));
   return index >= 0 && index < values_.size();
 }
 

--- a/bridge/core/timing/performance.cc
+++ b/bridge/core/timing/performance.cc
@@ -223,7 +223,7 @@ void Performance::measure(const AtomicString& measure_name,
   if (start_mark_count == 0) {
     exception_state.ThrowException(
         ctx(), ErrorType::TypeError,
-        "Failed to execute 'measure' on 'Performance': The mark " + start_mark.ToStdString() + " does not exist.");
+        "Failed to execute 'measure' on 'Performance': The mark " + start_mark.ToStdString(ctx()) + " does not exist.");
     return;
   }
 
@@ -233,14 +233,14 @@ void Performance::measure(const AtomicString& measure_name,
   if (end_mark_count == 0) {
     exception_state.ThrowException(
         ctx(), ErrorType::TypeError,
-        "Failed to execute 'measure' on 'Performance': The mark " + end_mark.ToStdString() + " does not exist.");
+        "Failed to execute 'measure' on 'Performance': The mark " + end_mark.ToStdString(ctx()) + " does not exist.");
     return;
   }
 
   if (start_mark_count != end_mark_count) {
     exception_state.ThrowException(ctx(), ErrorType::TypeError,
                                    "Failed to execute 'measure' on 'Performance': The mark " +
-                                       start_mark.ToStdString() + " and " + end_mark.ToStdString() +
+                                       start_mark.ToStdString(ctx()) + " and " + end_mark.ToStdString(ctx()) +
                                        " does not appear the same number of times");
     return;
   }
@@ -263,7 +263,7 @@ void Performance::measure(const AtomicString& measure_name,
     if (end_entry == entries_.end()) {
       size_t startIndex = start_entry - entries_.begin();
       assert_m(false, ("Can not get endEntry. startIndex: " + std::to_string(startIndex) +
-                       " startMark: " + start_mark.ToStdString() + " endMark: " + end_mark.ToStdString()));
+                       " startMark: " + start_mark.ToStdString(ctx()) + " endMark: " + end_mark.ToStdString(ctx())));
     }
 
     int64_t duration = (*end_entry)->startTime() - (*start_entry)->startTime();

--- a/bridge/core/timing/performance_mark.cc
+++ b/bridge/core/timing/performance_mark.cc
@@ -21,7 +21,7 @@ PerformanceMark* PerformanceMark::Create(ExecutingContext* context,
       start = mark_options->startTime();
       if (start < 0) {
         exception_state.ThrowException(context->ctx(), ErrorType::TypeError,
-                                       "'" + name.ToStdString() + "' cannot have a negative start time.");
+                                       "'" + name.ToStdString(context->ctx()) + "' cannot have a negative start time.");
         return nullptr;
       }
     } else {

--- a/bridge/foundation/native_value.cc
+++ b/bridge/foundation/native_value.cc
@@ -68,8 +68,7 @@ NativeValue Native_NewJSON(const ScriptValue& value, ExceptionState& exception_s
     return Native_NewNull();
   }
 
-  AtomicString str = json.ToString();
-  auto native_string = str.ToNativeString();
+  auto native_string = json.ToNativeString();
   NativeValue result = (NativeValue){
       .u = {.ptr = static_cast<void*>(native_string.release())},
       .uint32 = 0,

--- a/bridge/foundation/native_value_converter.h
+++ b/bridge/foundation/native_value_converter.h
@@ -33,7 +33,7 @@ struct NativeValueConverter<NativeTypeNull> : public NativeValueConverterBase<Na
 
 template <>
 struct NativeValueConverter<NativeTypeString> : public NativeValueConverterBase<NativeTypeString> {
-  static NativeValue ToNativeValue(const ImplType& value) { return Native_NewString(value.ToNativeString().release()); }
+  static NativeValue ToNativeValue(JSContext* ctx, const ImplType& value) { return Native_NewString(value.ToNativeString(ctx).release()); }
 
   static ImplType FromNativeValue(JSContext* ctx, NativeValue value) {
     if (value.tag == NativeTag::TAG_NULL) {

--- a/bridge/foundation/native_value_converter.h
+++ b/bridge/foundation/native_value_converter.h
@@ -33,7 +33,9 @@ struct NativeValueConverter<NativeTypeNull> : public NativeValueConverterBase<Na
 
 template <>
 struct NativeValueConverter<NativeTypeString> : public NativeValueConverterBase<NativeTypeString> {
-  static NativeValue ToNativeValue(JSContext* ctx, const ImplType& value) { return Native_NewString(value.ToNativeString(ctx).release()); }
+  static NativeValue ToNativeValue(JSContext* ctx, const ImplType& value) {
+    return Native_NewString(value.ToNativeString(ctx).release());
+  }
 
   static ImplType FromNativeValue(JSContext* ctx, NativeValue value) {
     if (value.tag == NativeTag::TAG_NULL) {

--- a/bridge/scripts/code_generator/src/idl/generateSource.ts
+++ b/bridge/scripts/code_generator/src/idl/generateSource.ts
@@ -164,6 +164,10 @@ export function generateIDLTypeConverter(type: ParameterType[], isOptional?: boo
   return returnValue;
 }
 
+function isDOMStringType(type: ParameterType[]) {
+  return type[0] == FunctionArgumentType.dom_string;
+}
+
 function generateNativeValueTypeConverter(type: ParameterType[]): string {
   let returnValue = '';
 
@@ -217,7 +221,7 @@ function generateCallMethodName(name: string) {
 
 function generateDartImplCallCode(blob: IDLBlob, declare: FunctionDeclaration, args: FunctionArguments[]): string {
   let nativeArguments = args.map(i => {
-    return `NativeValueConverter<${generateNativeValueTypeConverter(i.type)}>::ToNativeValue(args_${i.name})`;
+    return `NativeValueConverter<${generateNativeValueTypeConverter(i.type)}>::ToNativeValue(${isDOMStringType(i.type) ? 'ctx, ' : ''}args_${i.name})`;
   });
 
   let returnValueAssignment = '';
@@ -520,7 +524,8 @@ const WrapperTypeInfo& ${getClassName(blob)}::wrapper_type_info_ = QJS${getClass
           overloadMethods,
           filtedMethods,
           generateIDLTypeConverter,
-          generateNativeValueTypeConverter
+          generateNativeValueTypeConverter,
+          isDOMStringType,
         });
       }
       case TemplateKind.Dictionary: {

--- a/bridge/scripts/code_generator/templates/idl_templates/interface.cc.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/interface.cc.tpl
@@ -175,7 +175,7 @@ static JSValue <%= prop.name %>AttributeSetCallback(JSContext* ctx, JSValueConst
   MemberMutationScope scope{ExecutingContext::From(ctx)};
 
   <% if (prop.typeMode && prop.typeMode.dartImpl) { %>
-  <%= blob.filename %>->SetBindingProperty(binding_call_methods::k<%= prop.name %>, NativeValueConverter<<%= generateNativeValueTypeConverter(prop.type) %>>::ToNativeValue(v),exception_state);
+  <%= blob.filename %>->SetBindingProperty(binding_call_methods::k<%= prop.name %>, NativeValueConverter<<%= generateNativeValueTypeConverter(prop.type) %>>::ToNativeValue(<% if (isDOMStringType(prop.type)) { %>ctx, <% } %>v),exception_state);
   <% } else {%>
   <%= blob.filename %>->set<%= prop.name[0].toUpperCase() + prop.name.slice(1) %>(v, exception_state);
   <% } %>

--- a/bridge/test/webf_test_context.cc
+++ b/bridge/test/webf_test_context.cc
@@ -195,7 +195,7 @@ static JSValue parseHTML(JSContext* ctx, JSValueConst this_val, int argc, JSValu
   MemberMutationScope scope(context);
 
   if (argc == 1) {
-    std::string strHTML = AtomicString(ctx, argv[0]).ToStdString();
+    std::string strHTML = AtomicString(ctx, argv[0]).ToStdString(ctx);
     HTMLParser::parseHTML(strHTML, context->document()->documentElement());
   }
 

--- a/bridge/third_party/quickjs/include/quickjs/quickjs.h
+++ b/bridge/third_party/quickjs/include/quickjs/quickjs.h
@@ -439,6 +439,7 @@ JSAtom JS_NewAtomLen(JSContext *ctx, const char *str, size_t len);
 JSAtom JS_NewAtom(JSContext *ctx, const char *str);
 JSAtom JS_NewAtomUInt32(JSContext *ctx, uint32_t n);
 JSAtom JS_DupAtom(JSContext *ctx, JSAtom v);
+JSAtom JS_DupAtomRT(JSRuntime *runtime, JSAtom v);
 void JS_FreeAtom(JSContext *ctx, JSAtom v);
 void JS_FreeAtomRT(JSRuntime *rt, JSAtom v);
 JSValue JS_AtomToValue(JSContext *ctx, JSAtom atom);

--- a/bridge/third_party/quickjs/src/core/string.h
+++ b/bridge/third_party/quickjs/src/core/string.h
@@ -89,7 +89,6 @@ int JS_AtomIsNumericIndex(JSContext* ctx, JSAtom atom);
 /* Warning: 'p' is freed */
 JSAtom JS_NewAtomStr(JSContext* ctx, JSString* p);
 __maybe_unused void JS_DumpAtoms(JSRuntime* rt);
-JSAtom JS_DupAtomRT(JSRuntime* rt, JSAtom v);
 JSAtomKindEnum JS_AtomGetKind(JSContext* ctx, JSAtom v);
 BOOL JS_AtomIsString(JSContext* ctx, JSAtom v);
 JSAtom js_get_atom_index(JSRuntime* rt, JSAtomStruct* p);

--- a/bridge/third_party/quickjs/src/core/types.h
+++ b/bridge/third_party/quickjs/src/core/types.h
@@ -35,6 +35,10 @@
 #include "quickjs/libbf.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
     /* classid tag        */    /* union usage   | properties */
     JS_CLASS_OBJECT = 1,        /* must be first */
@@ -933,5 +937,9 @@ enum OPCodeEnum {
 #define ATOD_MODE_BIGINT      (1 << 9)
 /* accept -0x1 */
 #define ATOD_ACCEPT_PREFIX_AFTER_SIGN (1 << 10)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/integration_tests/lib/modules/unresponsive_module.dart
+++ b/integration_tests/lib/modules/unresponsive_module.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:webf/module.dart';
+
+class UnresponsiveModule extends BaseModule {
+  UnresponsiveModule(super.moduleManager);
+
+  @override
+  void dispose() {
+  }
+
+  @override
+  invoke(String method, params, InvokeModuleCallback callback) {
+    Timer(Duration(milliseconds: 800), () {
+      callback();
+    });
+  }
+
+  @override
+  String get name => 'UnresponsiveModule';
+}

--- a/integration_tests/lib/multiple_page.dart
+++ b/integration_tests/lib/multiple_page.dart
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2022-present The WebF authors. All rights reserved.
+ */
+import 'dart:async';
+import 'dart:io';
+
+import 'package:ansicolor/ansicolor.dart';
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as path;
+import 'package:webf/css.dart';
+import 'package:webf/webf.dart';
+import 'package:test/test.dart';
+
+import 'custom/custom_element.dart';
+import 'local_http_server.dart';
+import 'plugin.dart';
+import 'modules/unresponsive_module.dart';
+
+String? pass = (AnsiPen()..green())('[TEST PASS]');
+String? err = (AnsiPen()..red())('[TEST FAILED]');
+
+final String __dirname = path.dirname(Platform.script.path);
+final String testDirectory = Platform.environment['WEBF_TEST_DIR'] ?? __dirname;
+final GlobalKey<RootPageState> rootPageKey = GlobalKey();
+
+class MultiplePageState extends State<MultiplePage> {
+  BuildContext? _context;
+
+  void navigateBack() {
+    Navigator.pop(_context!);
+  }
+
+  WebF? webf;
+
+  @override
+  Widget build(BuildContext context) {
+    _context = context;
+    return webf = WebF(
+      viewportWidth: 360,
+      viewportHeight: 640,
+      bundle: WebFBundle.fromContent(widget.bundle, contentType: widget.contentType),
+      disableViewportWidthAssertion: true,
+      disableViewportHeightAssertion: true,
+      uriParser: IntegrationTestUriParser(),
+    );
+  }
+}
+
+class MultiplePage extends StatefulWidget {
+  final String bundle;
+  final String name;
+  final ContentType contentType;
+
+  MultiplePage(this.name, this.bundle, this.contentType, {super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    var state = MultiplePageState();
+    return state;
+  }
+}
+
+class MultiplePageKey extends LabeledGlobalKey<MultiplePageState> {
+  final String name;
+  MultiplePageKey(this.name): super('$name');
+
+  @override
+  bool operator ==(other) {
+    return other is MultiplePageKey && other.name == name;
+  }
+
+  @override
+  int get hashCode => super.hashCode;
+}
+
+class MultiplePageController {
+  Map<String, MultiplePageKey> _keys = {};
+
+  MultiplePageKey createKey(String name) {
+    MultiplePageKey key = MultiplePageKey(name);
+    _keys[name] = key;
+    return key;
+  }
+
+  MultiplePageState? state(String name) => _keys[name]!.currentState;
+
+  WebFController getWebF(String name) {
+    return _keys[name]!.currentState!.webf!.controller!;
+  }
+}
+
+class RootPage extends StatefulWidget {
+  RootPage({super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return RootPageState();
+  }
+}
+
+class RootPageState extends State<RootPage> {
+  BuildContext? _context;
+  Future<void> navigateToPage(String nextPage) {
+    return Navigator.pushNamed(_context!, '/$nextPage');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _context = context;
+    return Center(child: Text('root'));
+  }
+}
+
+class CodeUnit {
+  final String name;
+  final String code;
+  final ContentType contentType;
+  CodeUnit(this.name, this.code, this.contentType);
+}
+
+Map<String, WidgetBuilder> buildRoutes(MultiplePageController pageController, List<CodeUnit> codes) {
+  Map<String, WidgetBuilder> routes = {};
+  codes.forEach((code) {
+    routes['/${code.name}'] = (context) => Scaffold(
+      appBar: AppBar(title: Text('WebF Multiple Page Tests')),
+      body: MultiplePage(code.name, code.code, code.contentType, key: pageController.createKey(code.name)),
+    );
+  });
+  routes['/'] = (context) => Scaffold(
+    appBar: AppBar(title: Text('WebF Multiple Page Tests')),
+    body: RootPage(key: rootPageKey)
+  );
+  return routes;
+}
+
+String getFileName(String path) {
+  return path.split('/').last;
+}
+
+ContentType getFileContentType(String fileName) {
+  if (fileName.contains('.html')) {
+    return htmlContentType;
+  }
+  if (fileName.contains('.kbc')) {
+    return webfBc1ContentType;
+  }
+  return javascriptContentType;
+}
+
+void main() {
+  // Overrides library name.
+  WebFDynamicLibrary.libName = 'libwebf_test';
+  defineWebFCustomElements();
+
+  ModuleManager.defineModule((moduleManager) => UnresponsiveModule(moduleManager));
+
+  // Start local HTTP server.
+  var httpServer = LocalHttpServer.getInstance();
+  print('Local HTTP server started at: ${httpServer.getUri()}');
+
+  // Set render font family AlibabaPuHuiTi to resolve rendering difference.
+  CSSText.DEFAULT_FONT_FAMILY_FALLBACK = ['AlibabaPuHuiTi'];
+
+  final String specFolder = 'multiple_page_specs';
+  final dir = Directory(path.join(testDirectory, specFolder));
+  List<FileSystemEntity> specs = dir.listSync();
+  WebFJavaScriptChannel javaScriptChannel = WebFJavaScriptChannel();
+  javaScriptChannel.onMethodCall = (String method, dynamic arguments) async {
+    dynamic returnedValue = await javaScriptChannel.invokeMethod(method, arguments);
+    return 'method: $method, return_type: ${returnedValue.runtimeType.toString()}, return_value: ${returnedValue.toString()}';
+  };
+
+  MultiplePageController pageController = MultiplePageController();
+  List<CodeUnit> codes = specs.map((spec) {
+    String fileName = getFileName(spec.path);
+    return CodeUnit(fileName, File(spec.path).readAsStringSync(), getFileContentType(fileName));
+  }).toList();
+  runApp(MaterialApp(
+    title: 'WebF Multiple Page Tests',
+    debugShowCheckedModeBanner: false,
+    initialRoute:  '/',
+    routes: buildRoutes(pageController, codes),
+  ));
+
+  WidgetsBinding.instance.addPostFrameCallback((_) async {
+    group('Multiple page switching', () {
+      tearDown(() {
+        Completer completer = Completer();
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          completer.complete();
+        });
+        return completer.future;
+      });
+
+      specs.forEach((spec) {
+        String specName = getFileName(spec.path);
+
+        test(specName, () async {
+          Completer completer = Completer();
+          rootPageKey.currentState!.navigateToPage(specName);
+
+
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            MultiplePageState state = pageController.state(specName)!;
+            state.webf!.controller!.onLoad = (_) {
+              Timer(Duration(milliseconds: 500), () async {
+                await state.webf!.controller!.reload();
+                Timer(Duration(milliseconds: 500), () async {
+                  await state.webf!.controller!.reload();
+                  state.navigateBack();
+                  completer.complete();
+                });
+              });
+            };
+          });
+
+          return completer.future;
+        });
+      });
+
+      tearDownAll(() {
+        print('test done');
+        // exit(0);
+      });
+    });
+  });
+}

--- a/integration_tests/lib/multiple_page.dart
+++ b/integration_tests/lib/multiple_page.dart
@@ -220,7 +220,7 @@ void main() {
 
       tearDownAll(() {
         print('test done');
-        // exit(0);
+        exit(0);
       });
     });
   });

--- a/integration_tests/multiple_page_specs/invoke_unresponsive_module_api.html
+++ b/integration_tests/multiple_page_specs/invoke_unresponsive_module_api.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Invoke unresponsive module API</title>
+</head>
+<body>
+  <p>This page will invoke unresponsive module API</p>
+</body>
+<script>
+  asyncStorage.setItem('key', 1234);
+  webf.invokeModule('UnresponsiveModule', 'unresponsive', null, (err, data) => {
+     console.log('never returned');
+  });
+</script>
+</html>

--- a/integration_tests/multiple_page_specs/long_request_animation_frame.html
+++ b/integration_tests/multiple_page_specs/long_request_animation_frame.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Long RequestAnimationFrame</title>
+</head>
+<body>
+  <p>The request animation frame callback won't called util dispose this page.</p>
+</body>
+<script>
+  function recursive() {
+      requestAnimationFrame(recursive);
+  }
+  requestAnimationFrame(recursive);
+</script>
+</html>

--- a/integration_tests/multiple_page_specs/long_timer.html
+++ b/integration_tests/multiple_page_specs/long_timer.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Long Timer</title>
+</head>
+<body>
+  <p>The lone timer won't stop util dispose this page.</p>
+</body>
+<script>
+function timer() {
+  setTimeout(timer, 100);
+}
+setTimeout(timer, 100);
+</script>
+</html>

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -5,12 +5,14 @@
     "test": "flutter clean && flutter pub get && npm run clean && npm run integration",
     "posttest": "npm run lint",
     "plugin_test": "npm run pretest && flutter clean && flutter pub get && npm run clean && npm run lint && npm run plugin_integration",
+    "multiple_page_test": "npm run pretest && flutter clean && flutter pub get && npm run clean && npm run lint && npm run multiple_page_integration",
     "lint": "cd ../ && npm run lint",
     "clean": "rm -rf ./.specs && git clean -xfd ./snapshots",
     "specs": "webpack --config ./webpack.config.js",
     "prettier": "prettier --no-config --single-quote --trailing-comma=es5 --write ./specs/{.,**,**/**}/*.ts",
     "integration": "npm run clean && npm run specs && node scripts/core_integration_starter",
-    "plugin_integration": "npm run specs && node scripts/plugin_integration_starter"
+    "plugin_integration": "npm run specs && node scripts/plugin_integration_starter",
+    "multiple_page_integration": "node scripts/multiple_page_integration"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/integration_tests/pubspec.yaml
+++ b/integration_tests/pubspec.yaml
@@ -14,7 +14,7 @@ description: Integration tests for webf.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependency_overrides:
   webf:
@@ -29,7 +29,7 @@ dependencies:
   webf_websocket: ^1.1.0-beta.2
   waterfall_flow: ^3.0.1
   image_compare: ^1.1.2
-  
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/integration_tests/scripts/multiple_page_integration.js
+++ b/integration_tests/scripts/multiple_page_integration.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022-present The Kraken authors. All rights reserved.
+ */
+const { spawn, spawnSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+
+// Dart null safety error didn't report in dist binaries. Should run integration test with flutter run directly.
+function startIntegrationTest() {
+  const shouldSkipBuild = /skip\-build/.test(process.argv);
+  if (!shouldSkipBuild) {
+    spawnSync('flutter', ['build', 'macos', '--debug', '--target=lib/multiple_page.dart'], {
+      stdio: 'inherit'
+    });
+  }
+
+  const platform = os.platform();
+  let testExecutable;
+  if (platform === 'linux') {
+    testExecutable = path.join(__dirname, '../build/linux/x64/debug/bundle/app');
+  } else if (platform === 'darwin') {
+    testExecutable = path.join(__dirname, '../build/macos/Build/Products/Debug/tests.app/Contents/MacOS/tests');
+  } else {
+    throw new Error('Unsupported platform:' + platform);
+  }
+
+  const tester = spawn(testExecutable, [], {
+    env: {
+      ...process.env,
+      WEBF_ENABLE_TEST: 'true',
+      'enable-software-rendering': true,
+      'skia-deterministic-rendering': true,
+      WEBF_TEST_DIR: path.join(__dirname, '../')
+    },
+    cwd: process.cwd(),
+    stdio: 'inherit'
+  });
+
+  tester.on('close', (code) => {
+    process.exit(code);
+  });
+  tester.on('error', (error) => {
+    console.error('integration failed', error);
+    process.exit(1);
+  });
+  tester.on('exit', (code, signal) => {
+    if (signal) {
+      console.log('Process exit with ' + signal);
+      process.exit(1);
+    }
+    if (code != 0) {
+      process.exit(1);
+    }
+  });
+}
+
+startIntegrationTest();

--- a/webf/lib/src/foundation/bundle.dart
+++ b/webf/lib/src/foundation/bundle.dart
@@ -18,10 +18,11 @@ const String UTF_8 = 'utf-8';
 
 final ContentType _cssContentType = ContentType('text', 'css', charset: UTF_8);
 // MIME types suits JavaScript: https://mathiasbynens.be/demo/javascript-mime-type
-final ContentType _javascriptContentType = ContentType('text', 'javascript', charset: UTF_8);
+final ContentType javascriptContentType = ContentType('text', 'javascript', charset: UTF_8);
+final ContentType htmlContentType = ContentType('text', 'html', charset: UTF_8);
 final ContentType _javascriptApplicationContentType = ContentType('application', 'javascript', charset: UTF_8);
 final ContentType _xJavascriptContentType = ContentType('application', 'x-javascript', charset: UTF_8);
-final ContentType _webfBc1ContentType = ContentType('application', 'vnd.webf.bc1');
+final ContentType webfBc1ContentType = ContentType('application', 'vnd.webf.bc1');
 
 const List<String> _supportedByteCodeVersions = ['1'];
 
@@ -118,24 +119,24 @@ abstract class WebFBundle {
     } else if (_isDataScheme(url)) {
       return DataBundle.fromDataUrl(url);
     } else if (_isDefaultUrl(url)) {
-      return DataBundle.fromString('', url, contentType: _javascriptContentType);
+      return DataBundle.fromString('', url, contentType: javascriptContentType);
     } else {
       throw FlutterError('Unsupported url. $url');
     }
   }
 
-  static WebFBundle fromContent(String content, {String url = DEFAULT_URL}) {
-    return DataBundle.fromString(content, url, contentType: _javascriptContentType);
+  static WebFBundle fromContent(String content, {String url = DEFAULT_URL, ContentType? contentType}) {
+    return DataBundle.fromString(content, url, contentType: contentType ?? javascriptContentType);
   }
 
   static WebFBundle fromBytecode(Uint8List data, {String url = DEFAULT_URL}) {
-    return DataBundle(data, url, contentType: _webfBc1ContentType);
+    return DataBundle(data, url, contentType: webfBc1ContentType);
   }
 
   bool get isHTML => contentType.mimeType == ContentType.html.mimeType;
   bool get isCSS => contentType.mimeType == _cssContentType.mimeType;
   bool get isJavascript =>
-      contentType.mimeType == _javascriptContentType.mimeType ||
+      contentType.mimeType == javascriptContentType.mimeType ||
       contentType.mimeType == _javascriptApplicationContentType.mimeType ||
       contentType.mimeType == _xJavascriptContentType.mimeType;
   bool get isBytecode => _isSupportedBytecode(contentType.mimeType, _uri);
@@ -265,7 +266,7 @@ mixin _ExtensionContentTypeResolver on WebFBundle {
     } else if (_isUriExt(uri, '.html')) {
       return ContentType.html;
     } else if (_isSupportedBytecode('', uri)) {
-      return _webfBc1ContentType;
+      return webfBc1ContentType;
     } else if (_isUriExt(uri, '.css')) {
       return _cssContentType;
     }

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -1092,6 +1092,8 @@ class WebFController {
     _controllerMap[_view.contextId] = null;
     _controllerMap.remove(_view.contextId);
     _nameIdMap.remove(name);
+    // To release entrypoint bundle memory.
+    _entrypoint?.dispose();
 
     devToolsService?.dispose();
   }
@@ -1204,9 +1206,6 @@ class WebFController {
       if (kProfileMode) {
         PerformanceTiming.instance().mark(PERF_JS_BUNDLE_EVAL_END);
       }
-
-      // To release entrypoint bundle memory.
-      entrypoint.dispose();
 
       // trigger DOMContentLoaded event
       SchedulerBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
1. Fix the C++ bridge crash in two scenarios: 

+ The JSAtom can be shared between JSContexts, but we store the JSContext pointer at AtomicString class. That's a big mistake. If the previous stored JSContext are freeed, the bridge will crash if we copy previous JSContext allocated AtomicString to the current JSContext.
+ The InvokeModule API's callback could be called when the JSContext are already disposed in some special cases.

2. Add Multiple page integration test system.  Fixed #75
