### PR TITLE
[fix] Cannot find module 'qjsc'

### DIFF
--- a/bridge/polyfill/package.json
+++ b/bridge/polyfill/package.json
@@ -15,7 +15,7 @@
     "es6-promise": "^4.2.8",
     "event-emitter": "^0.3.5",
     "expect": "^25.1.0",
-    "qjsc": "0.2.2",
+    "qjsc": "0.3.0",
     "ts-jest": "^24.3.0",
     "tslib": "^1.11.2"
   },


### PR DESCRIPTION
version 0.2.2 cannot install
error message:
```log
Error: Cannot find module 'qjsc'
  at Object.<anonymous> (/Users/xxx/webf/bridge/polyfill/scripts/js_to_c.js:2:14)
```