### PR TITLE
feat: AtomicString support null like empty string

### DIFF
--- a/.github/workflows/example_build.yml
+++ b/.github/workflows/example_build.yml
@@ -101,7 +101,9 @@ jobs:
       - uses: jwlawson/actions-setup-cmake@v1.11
         with:
           cmake-version: ${{ env.cmakeVersion }}
-
+      - run: |
+          sudo apt-get update
+          sudo apt-get install chrpath ninja-build pkg-config libgtk-3-dev -y
       - run: npm i
       - run: npm run build:bridge:linux:release
 
@@ -109,9 +111,6 @@ jobs:
         with:
           flutter-version: ${{ env.flutterVersion }}
       - run: flutter config --enable-linux-desktop
-      - run: |
-          sudo apt-get update
-          sudo apt-get install ninja-build pkg-config libgtk-3-dev -y
       - run: flutter doctor -v
       - name: linux app build
         run: |

--- a/.github/workflows/integration_test_flutter.yml
+++ b/.github/workflows/integration_test_flutter.yml
@@ -46,6 +46,9 @@ jobs:
     - uses: jwlawson/actions-setup-cmake@v1.11
       with:
         cmake-version: ${{ env.cmakeVersion }}
+    - run: |
+        sudo apt-get update
+        sudo apt-get install chrpath ninja-build pkg-config -y
     - run: npm i
     - run: ENABLE_ASAN=true npm run build:bridge:linux
     - run: node scripts/run_bridge_unit_test.js

--- a/bridge/bindings/qjs/atomic_string.cc
+++ b/bridge/bindings/qjs/atomic_string.cc
@@ -12,6 +12,10 @@ AtomicString AtomicString::Empty() {
   return built_in_string::kempty_string;
 }
 
+AtomicString AtomicString::Null() {
+  return built_in_string::kNULL;
+}
+
 AtomicString AtomicString::From(JSContext* ctx, NativeString* native_string) {
   JSValue str = JS_NewUnicodeString(ctx, native_string->string(), native_string->length());
   auto result = AtomicString(ctx, str);
@@ -68,7 +72,7 @@ AtomicString::StringKind GetStringKind(const NativeString* native_string) {
 
 AtomicString::AtomicString(JSContext* ctx, const std::string& string)
     : runtime_(JS_GetRuntime(ctx)),
-      atom_(JS_NewAtom(ctx, string.c_str())),
+      atom_(JS_NewAtomLen(ctx, string.c_str(), string.size())),
       kind_(GetStringKind(string)),
       length_(string.size()) {}
 
@@ -79,36 +83,61 @@ AtomicString::AtomicString(JSContext* ctx, const NativeString* native_string)
       length_(native_string->length()) {}
 
 AtomicString::AtomicString(JSContext* ctx, JSValue value)
-    : runtime_(JS_GetRuntime(ctx)),
-      atom_(JS_IsNull(value) ? built_in_string::kempty_string.atom_ : JS_ValueToAtom(ctx, value)) {
+    : runtime_(JS_GetRuntime(ctx)), atom_(JS_ValueToAtom(ctx, value)) {
   if (JS_IsString(value)) {
     kind_ = GetStringKind(value);
     length_ = JS_VALUE_GET_STRING(value)->len;
+  } else {
+    initFromAtom(ctx);
   }
 }
 
 AtomicString::AtomicString(JSContext* ctx, JSAtom atom) : runtime_(JS_GetRuntime(ctx)), atom_(JS_DupAtom(ctx, atom)) {
-  JSValue string = JS_AtomToValue(ctx, atom);
-  kind_ = GetStringKind(string);
-  length_ = JS_VALUE_GET_STRING(string)->len;
-  JS_FreeValue(ctx, string);
+  initFromAtom(ctx);
+}
+
+void AtomicString::initFromAtom(JSContext* ctx) {
+  if (atom_ != JS_ATOM_NULL) {
+    auto atom_str = JS_AtomToValue(ctx, atom_);
+    kind_ = GetStringKind(atom_str);
+    length_ = JS_VALUE_GET_STRING(atom_str)->len;
+    JS_FreeValue(ctx, atom_str);
+  } else {
+    kind_ = StringKind::kIsMixed;
+    length_ = 0;
+    atom_upper_ = JS_ATOM_NULL;
+    atom_lower_ = JS_ATOM_NULL;
+  }
 }
 
 bool AtomicString::IsEmpty() const {
-  return *this == built_in_string::kempty_string;
+  return *this == built_in_string::kempty_string || IsNull();
+}
+
+bool AtomicString::IsNull() const {
+  return atom_ == JS_ATOM_NULL;
 }
 
 std::string AtomicString::ToStdString(JSContext* ctx) const {
   if (IsEmpty())
     return "";
 
-  const char* buf = JS_AtomToCString(ctx, atom_);
-  std::string result = std::string(buf);
+  JSValue str = JS_AtomToString(ctx, atom_);
+  size_t len;
+  const char* buf = JS_ToCStringLen(ctx, &len, str);
+  JS_FreeValue(ctx, str);
+
+  // to support \0 in JS string. So must be passing len.
+  std::string result = std::string(buf, len);
   JS_FreeCString(ctx, buf);
   return result;
 }
 
 std::unique_ptr<NativeString> AtomicString::ToNativeString(JSContext* ctx) const {
+  if (IsNull()) {
+    // Null string is same like empty string
+    return built_in_string::kempty_string.ToNativeString(ctx);
+  }
   JSValue stringValue = JS_AtomToValue(ctx, atom_);
   uint32_t length;
   uint16_t* bytes = JS_ToUnicode(ctx, stringValue, &length);
@@ -117,11 +146,18 @@ std::unique_ptr<NativeString> AtomicString::ToNativeString(JSContext* ctx) const
 }
 
 StringView AtomicString::ToStringView() const {
+  if (IsNull()) {
+    return built_in_string::kempty_string.ToStringView();
+  }
   return JSAtomToStringView(runtime_, atom_);
 }
 
 AtomicString::AtomicString(const AtomicString& value) {
-  if (&value != this) {
+  if (value.IsNull()) {
+    atom_ = value.atom_;
+    atom_upper_ = value.atom_upper_;
+    atom_lower_ = value.atom_lower_;
+  } else if (&value != this) {
     atom_ = JS_DupAtomRT(value.runtime_, value.atom_);
   }
   runtime_ = value.runtime_;
@@ -130,7 +166,7 @@ AtomicString::AtomicString(const AtomicString& value) {
 }
 
 AtomicString& AtomicString::operator=(const AtomicString& other) {
-  if (&other != this) {
+  if (&other != this && !other.IsNull()) {
     JS_FreeAtomRT(other.runtime_, atom_);
     atom_ = JS_DupAtomRT(other.runtime_, other.atom_);
   }
@@ -141,7 +177,7 @@ AtomicString& AtomicString::operator=(const AtomicString& other) {
 }
 
 AtomicString::AtomicString(AtomicString&& value) noexcept {
-  if (&value != this) {
+  if (&value != this && !value.IsNull()) {
     atom_ = JS_DupAtomRT(value.runtime_, value.atom_);
   }
   runtime_ = value.runtime_;
@@ -150,7 +186,7 @@ AtomicString::AtomicString(AtomicString&& value) noexcept {
 }
 
 AtomicString& AtomicString::operator=(AtomicString&& value) noexcept {
-  if (&value != this) {
+  if (&value != this && !value.IsNull()) {
     atom_ = JS_DupAtomRT(value.runtime_, value.atom_);
   }
   runtime_ = value.runtime_;
@@ -163,14 +199,14 @@ AtomicString AtomicString::ToUpperIfNecessary(JSContext* ctx) const {
   if (kind_ == StringKind::kIsUpperCase) {
     return *this;
   }
-  if (atom_upper_ != JS_ATOM_empty_string)
+  if (atom_upper_ != JS_ATOM_NULL || IsNull())
     return *this;
   AtomicString upperString = ToUpperSlow(ctx);
   atom_upper_ = upperString.atom_;
   return upperString;
 }
 
-const AtomicString AtomicString::ToUpperSlow(JSContext* ctx) const {
+AtomicString AtomicString::ToUpperSlow(JSContext* ctx) const {
   const char* cptr = JS_AtomToCString(ctx, atom_);
   std::string str = std::string(cptr);
   std::transform(str.begin(), str.end(), str.begin(), toupper);
@@ -178,18 +214,18 @@ const AtomicString AtomicString::ToUpperSlow(JSContext* ctx) const {
   return AtomicString(ctx, str);
 }
 
-const AtomicString AtomicString::ToLowerIfNecessary(JSContext* ctx) const {
+AtomicString AtomicString::ToLowerIfNecessary(JSContext* ctx) const {
   if (kind_ == StringKind::kIsLowerCase) {
     return *this;
   }
-  if (atom_lower_ != JS_ATOM_empty_string)
+  if (atom_upper_ != JS_ATOM_NULL || IsNull())
     return *this;
   AtomicString lowerString = ToLowerSlow(ctx);
   atom_lower_ = lowerString.atom_;
   return lowerString;
 }
 
-const AtomicString AtomicString::ToLowerSlow(JSContext* ctx) const {
+AtomicString AtomicString::ToLowerSlow(JSContext* ctx) const {
   const char* cptr = JS_AtomToCString(ctx, atom_);
   std::string str = std::string(cptr);
   std::transform(str.begin(), str.end(), str.begin(), tolower);

--- a/bridge/bindings/qjs/atomic_string.h
+++ b/bridge/bindings/qjs/atomic_string.h
@@ -33,6 +33,7 @@ class AtomicString {
   };
 
   static AtomicString Empty();
+  static AtomicString Null();
   static AtomicString From(JSContext* ctx, NativeString* native_string);
 
   AtomicString() = default;
@@ -44,7 +45,7 @@ class AtomicString {
 
   // Return the undefined string value from atom key.
   JSValue ToQuickJS(JSContext* ctx) const {
-    if (ctx == nullptr) {
+    if (ctx == nullptr || IsNull()) {
       return JS_NULL;
     }
 
@@ -53,6 +54,7 @@ class AtomicString {
   };
 
   bool IsEmpty() const;
+  bool IsNull() const;
 
   JSAtom Impl() const { return atom_; }
 
@@ -64,10 +66,10 @@ class AtomicString {
   StringView ToStringView() const;
 
   AtomicString ToUpperIfNecessary(JSContext* ctx) const;
-  const AtomicString ToUpperSlow(JSContext* ctx) const;
+  AtomicString ToUpperSlow(JSContext* ctx) const;
 
-  const AtomicString ToLowerIfNecessary(JSContext* ctx) const;
-  const AtomicString ToLowerSlow(JSContext* ctx) const;
+  AtomicString ToLowerIfNecessary(JSContext* ctx) const;
+  AtomicString ToLowerSlow(JSContext* ctx) const;
 
   // Copy assignment
   AtomicString(AtomicString const& value);
@@ -86,9 +88,12 @@ class AtomicString {
   JSRuntime* runtime_{nullptr};
   int64_t length_{0};
   JSAtom atom_{JS_ATOM_empty_string};
-  mutable JSAtom atom_upper_{JS_ATOM_empty_string};
-  mutable JSAtom atom_lower_{JS_ATOM_empty_string};
+  mutable JSAtom atom_upper_{JS_ATOM_NULL};
+  mutable JSAtom atom_lower_{JS_ATOM_NULL};
   StringKind kind_;
+
+ private:
+  void initFromAtom(JSContext* ctx);
 };
 
 }  // namespace webf

--- a/bridge/bindings/qjs/converter_impl.h
+++ b/bridge/bindings/qjs/converter_impl.h
@@ -244,9 +244,22 @@ struct Converter<IDLOptional<IDLDOMString>> : public ConverterBase<IDLDOMString>
 template <>
 struct Converter<IDLNullable<IDLDOMString>> : public ConverterBase<IDLDOMString> {
   static ImplType FromValue(JSContext* ctx, JSValue value, ExceptionState& exception_state) {
-    if (JS_IsNull(value))
-      return AtomicString::Empty();
+    if (JS_IsNull(value) || JS_IsUndefined(value))
+      return AtomicString::Null();
     return Converter<IDLDOMString>::FromValue(ctx, value, exception_state);
+  }
+
+  static JSValue ToValue(JSContext* ctx, const std::string& value) { return AtomicString(ctx, value).ToQuickJS(ctx); }
+  static JSValue ToValue(JSContext* ctx, const AtomicString& value) { return value.ToQuickJS(ctx); }
+};
+
+template <>
+struct Converter<IDLLegacyDOMString> : public ConverterBase<IDLLegacyDOMString> {
+  static ImplType FromValue(JSContext* ctx, JSValue value, ExceptionState& exception_state) {
+    if (JS_IsNull(value)) {
+      return AtomicString::Empty();
+    }
+    return AtomicString(ctx, value);
   }
 
   static JSValue ToValue(JSContext* ctx, const std::string& value) { return AtomicString(ctx, value).ToQuickJS(ctx); }

--- a/bridge/bindings/qjs/idl_type.h
+++ b/bridge/bindings/qjs/idl_type.h
@@ -49,6 +49,10 @@ class NativeString;
 // https://stackoverflow.com/questions/35123890/what-is-a-domstring-really
 struct IDLDOMString final : public IDLTypeBaseHelper<AtomicString> {};
 
+// DOMString with [LegacyNullToEmptyString] attribute
+// https://webidl.spec.whatwg.org/#LegacyNullToEmptyString
+struct IDLLegacyDOMString final : public IDLTypeBaseHelper<AtomicString> {};
+
 // https://developer.mozilla.org/en-US/docs/Web/API/USVString
 struct IDLUSVString final : public IDLTypeBaseHelper<AtomicString> {};
 

--- a/bridge/core/built_in_string.json5
+++ b/bridge/core/built_in_string.json5
@@ -11,6 +11,7 @@
     ]
   },
   "data": [
+    "NULL",
     "null",
     "false",
     "true",

--- a/bridge/core/css/legacy/css_style_declaration.d.ts
+++ b/bridge/core/css/legacy/css_style_declaration.d.ts
@@ -4,11 +4,11 @@ export interface CSSStyleDeclaration {
   // @ts-ignore
   getPropertyValue(property: string): string;
   // @ts-ignore
-  setProperty(property: string, value: string): void;
+  setProperty(property: string, value: LegacyNullToEmptyString): void;
   // @ts-ignore
   removeProperty(property: string): string;
 
-  [prop: string]: string;
+  [prop: string]: LegacyNullToEmptyString;
 
   new(): void;
 }

--- a/bridge/core/dom/character_data.cc
+++ b/bridge/core/dom/character_data.cc
@@ -20,8 +20,8 @@ void CharacterData::setData(const AtomicString& data, ExceptionState& exception_
                                                        std::move(args_02), (void*)bindingObject());
 }
 
-std::string CharacterData::nodeValue() const {
-  return data_.ToStdString(ctx());
+AtomicString CharacterData::nodeValue() const {
+  return data_;
 }
 
 bool CharacterData::IsCharacterDataNode() const {

--- a/bridge/core/dom/character_data.h
+++ b/bridge/core/dom/character_data.h
@@ -20,7 +20,7 @@ class CharacterData : public Node {
   int64_t length() const { return data_.length(); };
   void setData(const AtomicString& data, ExceptionState& exception_state);
 
-  std::string nodeValue() const override;
+  AtomicString nodeValue() const override;
   bool IsCharacterDataNode() const override;
   void setNodeValue(const AtomicString&, ExceptionState&) override;
 

--- a/bridge/core/dom/container_node.cc
+++ b/bridge/core/dom/container_node.cc
@@ -348,8 +348,8 @@ void ContainerNode::CloneChildNodesFrom(const ContainerNode& node, CloneChildren
   }
 }
 
-std::string ContainerNode::nodeValue() const {
-  return "";
+AtomicString ContainerNode::nodeValue() const {
+  return AtomicString::Null();
 }
 
 ContainerNode::ContainerNode(TreeScope* tree_scope, ConstructionType type)

--- a/bridge/core/dom/container_node.h
+++ b/bridge/core/dom/container_node.h
@@ -49,7 +49,7 @@ class ContainerNode : public Node {
 
   void CloneChildNodesFrom(const ContainerNode&, CloneChildrenFlag);
 
-  std::string nodeValue() const override;
+  AtomicString nodeValue() const override;
 
   virtual bool ChildrenCanHaveStyle() const { return true; }
 

--- a/bridge/core/dom/document.cc
+++ b/bridge/core/dom/document.cc
@@ -89,8 +89,8 @@ std::string Document::nodeName() const {
   return "#document";
 }
 
-std::string Document::nodeValue() const {
-  return "";
+AtomicString Document::nodeValue() const {
+  return AtomicString::Null();
 }
 
 Node::NodeType Document::nodeType() const {

--- a/bridge/core/dom/document.h
+++ b/bridge/core/dom/document.h
@@ -53,7 +53,7 @@ class Document : public ContainerNode, public TreeScope {
   HTMLAllCollection* all();
 
   [[nodiscard]] std::string nodeName() const override;
-  [[nodiscard]] std::string nodeValue() const override;
+  [[nodiscard]] AtomicString nodeValue() const override;
   [[nodiscard]] NodeType nodeType() const override;
   [[nodiscard]] bool ChildTypeAllowed(NodeType) const override;
 

--- a/bridge/core/dom/document_fragment.cc
+++ b/bridge/core/dom/document_fragment.cc
@@ -29,8 +29,8 @@ Node::NodeType DocumentFragment::nodeType() const {
   return NodeType::kDocumentFragmentNode;
 }
 
-std::string DocumentFragment::nodeValue() const {
-  return "";
+AtomicString DocumentFragment::nodeValue() const {
+  return AtomicString::Null();
 }
 
 Node* DocumentFragment::Clone(Document& factory, CloneChildrenFlag flag) const {

--- a/bridge/core/dom/document_fragment.h
+++ b/bridge/core/dom/document_fragment.h
@@ -24,7 +24,7 @@ class DocumentFragment : public ContainerNode {
   // This will catch anyone doing an unnecessary check.
   bool IsDocumentFragment() const = delete;
 
-  std::string nodeValue() const override;
+  AtomicString nodeValue() const override;
 
  protected:
   std::string nodeName() const final;

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -137,8 +137,8 @@ bool Element::HasTagName(const AtomicString& name) const {
   return name == tag_name_;
 }
 
-std::string Element::nodeValue() const {
-  return "";
+AtomicString Element::nodeValue() const {
+  return AtomicString::Null();
 }
 
 std::string Element::nodeName() const {

--- a/bridge/core/dom/element.h
+++ b/bridge/core/dom/element.h
@@ -55,7 +55,7 @@ class Element : public ContainerNode {
   void setInnerHTML(const AtomicString& value, ExceptionState& exception_state);
 
   bool HasTagName(const AtomicString&) const;
-  std::string nodeValue() const override;
+  AtomicString nodeValue() const override;
   AtomicString tagName() const { return tag_name_.ToUpperSlow(ctx()); }
   std::string nodeName() const override;
   std::string nodeNameLowerCase() const;

--- a/bridge/core/dom/node.cc
+++ b/bridge/core/dom/node.cc
@@ -227,7 +227,7 @@ AtomicString Node::textContent(bool convert_brs_to_newlines) const {
   // Documents and non-container nodes (that are not CharacterData)
   // have null textContent.
   if (IsDocumentNode() || !IsContainerNode())
-    return AtomicString::Empty();
+    return AtomicString::Null();
 
   std::string content;
   for (const Node& node : NodeTraversal::InclusiveDescendantsOf(*this)) {

--- a/bridge/core/dom/node.h
+++ b/bridge/core/dom/node.h
@@ -73,7 +73,7 @@ class Node : public EventTarget {
 
   // DOM methods & attributes for Node
   virtual std::string nodeName() const = 0;
-  virtual std::string nodeValue() const = 0;
+  virtual AtomicString nodeValue() const = 0;
   virtual void setNodeValue(const AtomicString&, ExceptionState&);
   virtual NodeType nodeType() const = 0;
 

--- a/bridge/scripts/code_generator/global.d.ts
+++ b/bridge/scripts/code_generator/global.d.ts
@@ -8,6 +8,8 @@ declare interface BlobPropertyBag {}
 declare function Dictionary() : any;
 declare type JSEventListener = void;
 
+declare type LegacyNullToEmptyString = string | null;
+
 // This property is implemented by Dart side
 type DartImpl<T> = T;
 type StaticMember<T> = T;

--- a/bridge/scripts/code_generator/src/idl/analyzer.ts
+++ b/bridge/scripts/code_generator/src/idl/analyzer.ts
@@ -117,6 +117,8 @@ function getParameterBaseType(type: ts.TypeNode, mode?: ParameterMode): Paramete
       let argument = typeReference.typeArguments![0];
       // @ts-ignore
       return getParameterBaseType(argument);
+    } else if (identifier === 'LegacyNullToEmptyString') {
+      return FunctionArgumentType.legacy_dom_string;
     }
 
     return identifier;

--- a/bridge/scripts/code_generator/src/idl/declaration.ts
+++ b/bridge/scripts/code_generator/src/idl/declaration.ts
@@ -15,6 +15,8 @@ export enum FunctionArgumentType {
   null,
   undefined,
   array,
+  // enable LegacyNullToEmpty attribute for dom_string
+  legacy_dom_string,
 }
 
 export class FunctionArguments {

--- a/bridge/scripts/code_generator/src/idl/generateSource.ts
+++ b/bridge/scripts/code_generator/src/idl/generateSource.ts
@@ -61,7 +61,8 @@ export function generateCoreTypeValue(type: ParameterType[]): string {
     case FunctionArgumentType.boolean: {
       return 'bool';
     }
-    case FunctionArgumentType.dom_string: {
+    case FunctionArgumentType.dom_string:
+    case FunctionArgumentType.legacy_dom_string: {
       return 'AtomicString';
     }
     case FunctionArgumentType.any: {
@@ -90,7 +91,8 @@ export function generateRawTypeValue(type: ParameterType[], is32Bit: boolean = f
     case FunctionArgumentType.boolean: {
       return 'int64_t';
     }
-    case FunctionArgumentType.dom_string: {
+    case FunctionArgumentType.dom_string:
+    case FunctionArgumentType.legacy_dom_string: {
       if (is32Bit) {
         return 'int64_t';
       }
@@ -148,6 +150,10 @@ export function generateIDLTypeConverter(type: ParameterType[], isOptional?: boo
       case FunctionArgumentType.promise:
         returnValue = 'IDLPromise';
         break;
+      case FunctionArgumentType.legacy_dom_string:
+        // TODO: legacy is now allowed with nullable
+        returnValue = 'IDLLegacyDOMString'
+        break;
       default:
       case FunctionArgumentType.any:
         returnValue = `IDLAny`;
@@ -165,7 +171,7 @@ export function generateIDLTypeConverter(type: ParameterType[], isOptional?: boo
 }
 
 function isDOMStringType(type: ParameterType[]) {
-  return type[0] == FunctionArgumentType.dom_string;
+  return type[0] === FunctionArgumentType.dom_string || type[0] === FunctionArgumentType.legacy_dom_string;
 }
 
 function generateNativeValueTypeConverter(type: ParameterType[]): string {
@@ -189,6 +195,7 @@ function generateNativeValueTypeConverter(type: ParameterType[]): string {
       returnValue = `NativeTypeBool`;
       break;
     case FunctionArgumentType.dom_string:
+    case FunctionArgumentType.legacy_dom_string:
       returnValue = `NativeTypeString`;
       break;
   }

--- a/integration_tests/specs/dom/nodes/nodeValue.ts
+++ b/integration_tests/specs/dom/nodes/nodeValue.ts
@@ -1,0 +1,80 @@
+// test from https://github.com/web-platform-tests/wpt/blob/master/dom/nodes/Node-nodeValue.html
+
+describe('Node.nodeValue', () => {
+    function test(fn, title) {
+        it(title, fn);
+    }
+
+    function xtest(fn, title) {
+        xit(title, fn)
+    }
+
+    function assert_equals(a: any, b: any) {
+        expect(a).toBe(b)
+    }
+
+    test(function () {
+        var the_text = document.createTextNode("A span!");
+        assert_equals(the_text.nodeValue, "A span!");
+        assert_equals(the_text.data, "A span!");
+        the_text.nodeValue = "test again";
+        assert_equals(the_text.nodeValue, "test again");
+        assert_equals(the_text.data, "test again");
+        the_text.nodeValue = null;
+        assert_equals(the_text.nodeValue, "");
+        assert_equals(the_text.data, "");
+    }, "Text.nodeValue");
+
+    // fix it later
+    xtest(function () {
+        var the_comment = document.createComment("A comment!");
+        assert_equals(the_comment.nodeValue, "A comment!");
+        assert_equals(the_comment.data, "A comment!");
+        the_comment.nodeValue = "test again";
+        assert_equals(the_comment.nodeValue, "test again");
+        assert_equals(the_comment.data, "test again");
+        the_comment.nodeValue = null;
+        assert_equals(the_comment.nodeValue, "");
+        assert_equals(the_comment.data, "");
+    }, "Comment.nodeValue");
+
+    // not support yet
+    xtest(function () {
+        var the_pi = document.createProcessingInstruction("pi", "A PI!");
+        assert_equals(the_pi.nodeValue, "A PI!");
+        assert_equals(the_pi.data, "A PI!");
+        the_pi.nodeValue = "test again";
+        assert_equals(the_pi.nodeValue, "test again");
+        assert_equals(the_pi.data, "test again");
+        the_pi.nodeValue = null;
+        assert_equals(the_pi.nodeValue, "");
+        assert_equals(the_pi.data, "");
+    }, "ProcessingInstruction.nodeValue");
+
+    test(function () {
+        var the_link = document.createElement("a");
+        assert_equals(the_link.nodeValue, null);
+        the_link.nodeValue = "foo";
+        assert_equals(the_link.nodeValue, null);
+    }, "Element.nodeValue");
+
+    test(function () {
+        assert_equals(document.nodeValue, null);
+        document.nodeValue = "foo";
+        assert_equals(document.nodeValue, null);
+    }, "Document.nodeValue");
+
+    test(function () {
+        var the_frag = document.createDocumentFragment();
+        assert_equals(the_frag.nodeValue, null);
+        the_frag.nodeValue = "foo";
+        assert_equals(the_frag.nodeValue, null);
+    }, "DocumentFragment.nodeValue");
+
+    xtest(function () {
+        var the_doctype = document.doctype!;
+        assert_equals(the_doctype.nodeValue, null);
+        the_doctype.nodeValue = "foo";
+        assert_equals(the_doctype.nodeValue, null);
+    }, "DocumentType.nodeValue");
+})

--- a/integration_tests/specs/dom/nodes/textContent.ts
+++ b/integration_tests/specs/dom/nodes/textContent.ts
@@ -1,0 +1,224 @@
+// test from https://github.com/web-platform-tests/wpt/blob/master/dom/nodes/Node-textContent.html
+
+describe('Node.textContent', () => {
+    function test(fn, title) {
+        it(title, fn);
+    }
+
+    function xtest(fn, title) {
+        xit(title, fn)
+    }
+
+    function assert_equals(a: any, b: any, message?: string) {
+        // TODO message
+        expect(a).toBe(b)
+    }
+
+    function assert_true(value: any, message?: string) {
+        expect(value).toBe(true)
+    }
+
+    function format_value(v: any) {
+        return JSON.stringify(v)
+    }
+
+    // Getting
+    // DocumentFragment, Element:
+    test(function () {
+        var element = document.createElement("div")
+        assert_equals(element.textContent, "")
+    }, "For an empty Element, textContent should be the empty string")
+
+    test(function () {
+        assert_equals(document.createDocumentFragment().textContent, "")
+    }, "For an empty DocumentFragment, textContent should be the empty string")
+
+    test(function () {
+        var el = document.createElement("div")
+        el.appendChild(document.createComment(" abc "))
+        el.appendChild(document.createTextNode("\tDEF\t"))
+        // el.appendChild(document.createProcessingInstruction("x", " ghi "))
+        assert_equals(el.textContent, "\tDEF\t")
+    }, "Element with children")
+
+    test(function () {
+        var el = document.createElement("div")
+        var child = document.createElement("div")
+        el.appendChild(child)
+        child.appendChild(document.createComment(" abc "))
+        child.appendChild(document.createTextNode("\tDEF\t"))
+        // child.appendChild(document.createProcessingInstruction("x", " ghi "))
+        assert_equals(el.textContent, "\tDEF\t")
+    }, "Element with descendants")
+
+    test(function () {
+        var df = document.createDocumentFragment()
+        df.appendChild(document.createComment(" abc "))
+        df.appendChild(document.createTextNode("\tDEF\t"))
+        // df.appendChild(document.createProcessingInstruction("x", " ghi "))
+        assert_equals(df.textContent, "\tDEF\t")
+    }, "DocumentFragment with children")
+
+    test(function () {
+        var df = document.createDocumentFragment()
+        var child = document.createElement("div")
+        df.appendChild(child)
+        child.appendChild(document.createComment(" abc "))
+        child.appendChild(document.createTextNode("\tDEF\t"))
+        // child.appendChild(document.createProcessingInstruction("x", " ghi "))
+        assert_equals(df.textContent, "\tDEF\t")
+    }, "DocumentFragment with descendants")
+
+    // Text, ProcessingInstruction, Comment:
+    test(function () {
+        assert_equals(document.createTextNode("").textContent, "")
+    }, "For an empty Text, textContent should be the empty string")
+
+    xtest(function () {
+        assert_equals(document.createProcessingInstruction("x", "").textContent, "")
+    }, "For an empty ProcessingInstruction, textContent should be the empty string")
+
+    test(function () {
+        assert_equals(document.createComment("").textContent, "")
+    }, "For an empty Comment, textContent should be the empty string")
+
+    test(function () {
+        assert_equals(document.createTextNode("abc").textContent, "abc")
+    }, "For a Text with data, textContent should be that data")
+
+    xtest(function () {
+        assert_equals(document.createProcessingInstruction("x", "abc").textContent,
+            "abc")
+    }, "For a ProcessingInstruction with data, textContent should be that data")
+
+    // fix it later
+    xtest(function () {
+        assert_equals(document.createComment("abc").textContent, "abc")
+    }, "For a Comment with data, textContent should be that data")
+
+    // Setting
+    // DocumentFragment, Element:
+    var testArgs = [
+        [null, null],
+        [undefined, null],
+        ["", null],
+        [42, "42"],
+        ["abc", "abc"],
+        ["<b>xyz<\/b>", "<b>xyz<\/b>"],
+        ["d\0e", "d\0e"]
+        // XXX unpaired surrogate?
+    ]
+    testArgs.forEach(function (aValue) {
+        var argument = aValue[0] as string, expectation = aValue[1]
+        var check = function (aElementOrDocumentFragment) {
+        if (expectation === null) {
+                assert_equals(aElementOrDocumentFragment.textContent, "")
+                assert_equals(aElementOrDocumentFragment.firstChild, null)
+            } else {
+                assert_equals(aElementOrDocumentFragment.textContent, expectation)
+                assert_equals(aElementOrDocumentFragment.childNodes.length, 1,
+                    "Should have one child")
+                var firstChild = aElementOrDocumentFragment.firstChild
+                assert_true(firstChild instanceof Text, "child should be a Text")
+                assert_equals(firstChild.data, expectation)
+            }
+        }
+
+        test(function () {
+            var el = document.createElement("div")
+            el.textContent = argument
+            check(el)
+        }, "Element without children set to " + format_value(argument))
+
+        test(function () {
+            var el = document.createElement("div")
+            var text = el.appendChild(document.createTextNode(""))
+            el.textContent = argument
+            check(el)
+            assert_equals(text.parentNode, null,
+                "Preexisting Text should have been removed")
+        }, "Element with empty text node as child set to " + format_value(argument))
+
+        test(function () {
+            var el = document.createElement("div")
+            el.appendChild(document.createComment(" abc "))
+            el.appendChild(document.createTextNode("\tDEF\t"))
+            // el.appendChild(document.createProcessingInstruction("x", " ghi "))
+            el.textContent = argument
+            check(el)
+        }, "Element with children set to " + format_value(argument))
+
+        test(function () {
+            var el = document.createElement("div")
+            var child = document.createElement("div")
+            el.appendChild(child)
+            child.appendChild(document.createComment(" abc "))
+            child.appendChild(document.createTextNode("\tDEF\t"))
+            // child.appendChild(document.createProcessingInstruction("x", " ghi "))
+            el.textContent = argument
+            check(el)
+            assert_equals(child.childNodes.length, 2,
+                "Should not have changed the internal structure of the removed nodes.")
+        }, "Element with descendants set to " + format_value(argument))
+
+        test(function () {
+            var df = document.createDocumentFragment()
+            df.textContent = argument
+            check(df)
+        }, "DocumentFragment without children set to " + format_value(argument))
+
+        test(function () {
+            var df = document.createDocumentFragment()
+            var text = df.appendChild(document.createTextNode(""))
+            df.textContent = argument
+            check(df)
+            assert_equals(text.parentNode, null,
+                "Preexisting Text should have been removed")
+        }, "DocumentFragment with empty text node as child set to " + format_value(argument))
+
+        test(function () {
+            var df = document.createDocumentFragment()
+            df.appendChild(document.createComment(" abc "))
+            df.appendChild(document.createTextNode("\tDEF\t"))
+            // df.appendChild(document.createProcessingInstruction("x", " ghi "))
+            df.textContent = argument
+            check(df)
+        }, "DocumentFragment with children set to " + format_value(argument))
+
+        test(function () {
+            var df = document.createDocumentFragment()
+            var child = document.createElement("div")
+            df.appendChild(child)
+            child.appendChild(document.createComment(" abc "))
+            child.appendChild(document.createTextNode("\tDEF\t"))
+            // child.appendChild(document.createProcessingInstruction("x", " ghi "))
+            df.textContent = argument
+            check(df)
+            assert_equals(child.childNodes.length, 2,
+                "Should not have changed the internal structure of the removed nodes.")
+        }, "DocumentFragment with descendants set to " + format_value(argument))
+    })
+
+    // Text, ProcessingInstruction, Comment:
+    test(function () {
+        var text = document.createTextNode("abc")
+        text.textContent = "def"
+        assert_equals(text.textContent, "def")
+        assert_equals(text.data, "def")
+    }, "For a Text, textContent should set the data")
+
+    xtest(function () {
+        var pi = document.createProcessingInstruction("x", "abc")
+        pi.textContent = "def"
+        assert_equals(pi.textContent, "def")
+        assert_equals(pi.data, "def")
+        assert_equals(pi.target, "x")
+    }, "For a ProcessingInstruction, textContent should set the data")
+
+    test(function () {
+        var comment = document.createComment("abc")
+        comment.textContent = "def"
+        assert_equals(comment.textContent, "def")
+        assert_equals(comment.data, "def")
+    }, "For a Comment, textContent should set the data")
+})


### PR DESCRIPTION
WebF doesn't support `DOMString?` DOM IDL type before. All `null` value is changed to
`''` empty string. This isn't right. This commit is to support it.

- AtomicString of empty string has two types now, '' and null.
- Add `IsNull()` instance method to check a string is null.
- Add `Null()` static method to get null string like `Empty()`.
- Add `LegacyNullToEmptyString` typescript type to implement `[LegacyNullToEmtpyString]` attribute for DOMString.
- Add test for textContent/nodeValue.
- Add `built_in_string::kNULL`.
- Support `\0` in AtomicString for set and get.
- Install chrpath for ci