### PR TITLE
fix: type 'Null' is not a subtype of type ...

### DIFF
--- a/webf/lib/src/rendering/box_model.dart
+++ b/webf/lib/src/rendering/box_model.dart
@@ -1367,14 +1367,16 @@ class RenderBoxModel extends RenderBox
     // It needs to find the previous sibling of the previous sibling if the placeholder of
     // positioned element exists and follows renderObject at the same time, eg.
     // <div style="position: relative"><div style="position: absolute" /></div>
-    if (renderPositionPlaceholder != null) {
+    if (renderPositionPlaceholder != null && renderPositionPlaceholder.parentData != null) {
       previousSibling = (renderPositionPlaceholder.parentData as ContainerParentDataMixin<RenderBox>).previousSibling;
       // The placeholder's previousSibling maybe the origin renderBox.
       if (previousSibling == renderBoxModel) {
         previousSibling = (renderBoxModel.parentData as ContainerParentDataMixin<RenderBox>).previousSibling;
       }
     } else {
-      previousSibling = (renderBoxModel.parentData as ContainerParentDataMixin<RenderBox>).previousSibling;
+      if (renderBoxModel.parentData != null) {
+        previousSibling = (renderBoxModel.parentData as ContainerParentDataMixin<RenderBox>).previousSibling;
+      }
     }
     return previousSibling;
   }


### PR DESCRIPTION
```log
type 'Null' is not a subtype of type 'ContainerParentDataMixin<RenderBox>' in type cast
    #0      RenderBoxModel.getPreviousSibling (package:webf/src/rendering/box_model.dart:1371:63)
    #1      Element.addToContainingBlock (package:webf/src/dom/element.dart:776:50)
    #2      Element._updateRenderBoxModelWithPosition.<anonymous closure> (package:webf/src/dom/element.dart:756:15)
    #3      List.forEach (dart:core-patch/growable_array.dart:433:8)
    #4      Element._updateRenderBoxModelWithPosition (package:webf/src/dom/element.dart:755:32)
    #5      Element.setRenderStyleProperty (package:webf/src/dom/element.dart:1247:9)
    #6      Element.setRenderStyle (package:webf/src/dom/element.dart:1536:5)
    #7      Element._onStyleChanged (package:webf/src/dom/element.dart:1613:7)
    #8      CSSStyleDeclaration._emitPropertyChanged (package:webf/src/css/style_declaration.dart:566:22)
    #9      CSSStyleDeclaration.flushPendingProperties (package:webf/src/css/style_declaration.dart:468:7)
    #10     Element.attachTo (packa

```