### PR TITLE
fix: sync gesture settings from window.

### DIFF
--- a/webf/lib/src/gesture/scrollable.dart
+++ b/webf/lib/src/gesture/scrollable.dart
@@ -3,6 +3,8 @@
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
 
+import 'dart:ui';
+
 import 'package:flutter/gestures.dart';
 import 'dart:math' as math;
 import 'package:flutter/physics.dart';
@@ -109,6 +111,8 @@ class WebFScrollable with _CustomTickerProviderStateMixin implements ScrollConte
 
   @override
   void setCanDrag(bool canDrag) {
+    DeviceGestureSettings gestureSettings = DeviceGestureSettings.fromWindow(window);
+
     // Break no use update drag logic
     if(canDrag == _lastCanDrag && axis == _lastAxisDirection &&
         (canDrag && _gestureRecognizers.keys.isNotEmpty ||
@@ -139,6 +143,7 @@ class WebFScrollable with _CustomTickerProviderStateMixin implements ScrollConte
                   ..minFlingDistance = _physics.minFlingDistance
                   ..minFlingVelocity = _physics.minFlingVelocity
                   ..maxFlingVelocity = _physics.maxFlingVelocity
+                  ..gestureSettings = gestureSettings
                   ..dragStartBehavior = dragStartBehavior;
               },
             ),
@@ -164,6 +169,7 @@ class WebFScrollable with _CustomTickerProviderStateMixin implements ScrollConte
                   ..minFlingDistance = _physics.minFlingDistance
                   ..minFlingVelocity = _physics.minFlingVelocity
                   ..maxFlingVelocity = _physics.maxFlingVelocity
+                  ..gestureSettings = gestureSettings
                   ..dragStartBehavior = dragStartBehavior;
               },
             ),

--- a/webf/lib/src/widget/widget_element.dart
+++ b/webf/lib/src/widget/widget_element.dart
@@ -38,6 +38,8 @@ abstract class WidgetElement extends dom.Element {
   // State methods, proxy called from _state
   void initState() {}
 
+  bool get mounted => _state?.mounted ?? false;
+
   // React to properties and attributes changes
   void attributeDidUpdate(String key, String value) {}
   bool shouldElementRebuild(String key, previousValue, nextValue) {


### PR DESCRIPTION
The touch slop is different between iOS and Android devices. Should read it from window instead of using defaults.