### PR TITLE
fix: fix history pushState()

### DIFF
--- a/integration_tests/specs/navigator/history.ts
+++ b/integration_tests/specs/navigator/history.ts
@@ -23,6 +23,14 @@ describe('history API', () => {
     });
   });
 
+  it('pushState with no url will default to current url', () => {
+    expect(location.pathname).toBe('/public/core.build.js');
+    history.pushState({name: 1}, '');
+    expect(location.pathname).toBe('/public/core.build.js');
+    expect(history.state).toEqual({name: 1});
+    history.back();
+  });
+
   it('replaceState should work', (done) => {
     expect(location.pathname).toBe('/public/core.build.js');
     history.replaceState({name: 0}, '');

--- a/webf/lib/src/module/history.dart
+++ b/webf/lib/src/module/history.dart
@@ -37,8 +37,6 @@ class HistoryModule extends BaseModule {
   }
 
   void _addItem(HistoryItem historyItem) {
-    if (_previousStack.isNotEmpty && historyItem.bundle.url == _previousStack.first.bundle.url) return;
-
     _previousStack.addFirst(historyItem);
 
     // Clear.
@@ -100,23 +98,21 @@ class HistoryModule extends BaseModule {
 
   void pushState(state, {String? url, String? title}) {
     WebFController controller = moduleManager!.controller;
-    if (url != null) {
-      String currentUrl = _previousStack.first.bundle.url;
-      Uri currentUri = Uri.parse(currentUrl);
+    String currentUrl = _previousStack.first.bundle.url;
+    url = url ?? currentUrl;
+    Uri uri = Uri.parse(url);
+    Uri currentUri = Uri.parse(currentUrl);
+    uri = controller.uriParser!.resolve(Uri.parse(controller.url), uri);
 
-      Uri uri = Uri.parse(url);
-      uri = controller.uriParser!.resolve(Uri.parse(controller.url), uri);
-
-      if (uri.host.isNotEmpty && uri.host != currentUri.host) {
-        print('Failed to execute \'pushState\' on \'History\': '
-            'A history state object with URL $url cannot be created in a document with origin ${uri.host} and URL ${currentUri.host}. "');
-        return;
-      }
-
-      WebFBundle bundle = WebFBundle.fromUrl(uri.toString());
-      HistoryItem history = HistoryItem(bundle, state, false);
-      _addItem(history);
+    if (uri.host.isNotEmpty && uri.host != currentUri.host) {
+      print('Failed to execute \'pushState\' on \'History\': '
+          'A history state object with URL $url cannot be created in a document with origin ${uri.host} and URL ${currentUri.host}. "');
+      return;
     }
+
+    WebFBundle bundle = WebFBundle.fromUrl(uri.toString());
+    HistoryItem history = HistoryItem(bundle, state, false);
+    _addItem(history);
   }
 
   void replaceState(state, {String? url, String? title}) {


### PR DESCRIPTION
support optional URL params for History.pushState API.