### PR TITLE
fix: fix widget element unmount renderObject.

### DIFF
--- a/integration_tests/specs/dom/elements/custom-element.ts
+++ b/integration_tests/specs/dom/elements/custom-element.ts
@@ -576,4 +576,22 @@ describe('custom html element', () => {
       done();
     }, 800);
   });
+
+  it('unmount widgetElements should works when contains image', async (done) => {
+    let container = document.createElement('flutter-container');
+    let img = document.createElement('img');
+    img.src = 'https://gw.alicdn.com/tfs/TB1CxCYq5_1gK0jSZFqXXcpaXXa-128-90.png';
+    let wrapper = createElement('div', {}, [
+      img
+    ]);
+    container.appendChild(wrapper);
+    document.body.appendChild(container);
+
+    img.onload = async () => {
+      requestAnimationFrame(() => {
+        document.body.removeChild(container);
+        done();
+      });
+    };
+  });
 });

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -174,7 +174,7 @@ class ImageElement extends Element {
       RenderReplaced renderReplaced = renderBoxModel as RenderReplaced;
       renderReplaced.child = null;
 
-      _renderImage?.dispose();
+      ownerDocument.inactiveRenderObjects.add(_renderImage);
       _renderImage = null;
     }
   }

--- a/webf/lib/src/widget/element_flutter_element_adapter.dart
+++ b/webf/lib/src/widget/element_flutter_element_adapter.dart
@@ -34,10 +34,8 @@ class WebFHTMLElementToFlutterElementAdaptor extends MultiChildRenderObjectEleme
   void unmount() {
     // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
     dom.Element element = widget.webFElement;
-
-    super.unmount();
-
     element.unmountRenderObject(dispose: false, fromFlutterWidget: true);
+    super.unmount();
   }
 
   @override


### PR DESCRIPTION
For WebFHTMLElementToFlutterElementAdaptor, should unmount all the children before unmounting itself.