### PR TITLE
fix: fix dom content loaded event trigger condition.

### DIFF
--- a/webf/lib/src/css/element_rule_collector.dart
+++ b/webf/lib/src/css/element_rule_collector.dart
@@ -6,6 +6,8 @@ import 'package:webf/css.dart';
 import 'package:webf/dom.dart';
 import 'package:webf/src/css/query_selector.dart';
 
+bool kShowUnavailableCSSProperties = false;
+
 class ElementRuleCollector {
   bool matchedAnyRule(RuleSet ruleSet, Element element) {
     return matchedRules(ruleSet, element).isNotEmpty;
@@ -86,7 +88,9 @@ class ElementRuleCollector {
           matchedRules.add(rule);
         }
       } catch (error) {
-        print('selector evaluator error: $error');
+        if (kShowUnavailableCSSProperties) {
+          print('selector evaluator error: $error');
+        }
       }
     }
     return matchedRules;

--- a/webf/lib/src/dom/document.dart
+++ b/webf/lib/src/dom/document.dart
@@ -150,6 +150,21 @@ class Document extends Node {
     }
   }
 
+  int _domContentLoadedEventDelayCount = 0;
+  bool get isDelayingDOMContentLoadedEvent => _domContentLoadedEventDelayCount > 0;
+  void incrementDOMContentLoadedEventDelayCount() {
+    _domContentLoadedEventDelayCount++;
+  }
+
+  void decrementDOMContentLoadedEventDelayCount() {
+    _domContentLoadedEventDelayCount--;
+
+    // Try to check when the request is complete.
+    if (_domContentLoadedEventDelayCount == 0) {
+      controller.checkCompleted();
+    }
+  }
+
   @override
   void initializeProperties(Map<String, BindingObjectProperty> properties) {
     properties['cookie'] = BindingObjectProperty(getter: () => cookie.cookie(), setter: (value) => cookie.setCookieString(value));

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -1292,13 +1292,10 @@ class WebFController {
   }
 
   void _dispatchDOMContentLoadedEvent() {
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      Event event = Event(EVENT_DOM_CONTENT_LOADED);
-      EventTarget window = view.window;
-      window.dispatchEvent(event);
-      _view.document.dispatchEvent(event);
-    });
-    SchedulerBinding.instance.scheduleFrame();
+    Event event = Event(EVENT_DOM_CONTENT_LOADED);
+    EventTarget window = view.window;
+    window.dispatchEvent(event);
+    _view.document.dispatchEvent(event);
   }
 
   void _dispatchWindowLoadEvent() {

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -1272,6 +1272,11 @@ class WebFController {
     // Are we still parsing?
     if (_view.document.parsing) return;
 
+    // Are all script element complete?
+    if (_view.document.isDelayingDOMContentLoadedEvent) return;
+
+    _dispatchDOMContentLoadedEvent();
+
     // Still waiting for images/scripts?
     if (_view.document.hasPendingRequest) return;
 
@@ -1283,7 +1288,6 @@ class WebFController {
 
     _isComplete = true;
 
-    _dispatchDOMContentLoadedEvent();
     _dispatchWindowLoadEvent();
   }
 
@@ -1294,6 +1298,7 @@ class WebFController {
       window.dispatchEvent(event);
       _view.document.dispatchEvent(event);
     });
+    SchedulerBinding.instance.scheduleFrame();
   }
 
   void _dispatchWindowLoadEvent() {

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -1258,14 +1258,6 @@ class WebFController {
       if (kProfileMode) {
         PerformanceTiming.instance().mark(PERF_JS_BUNDLE_EVAL_END);
       }
-
-      // trigger DOMContentLoaded event
-      SchedulerBinding.instance.addPostFrameCallback((_) {
-        Event event = Event(EVENT_DOM_CONTENT_LOADED);
-        EventTarget window = view.window;
-        window.dispatchEvent(event);
-      });
-      SchedulerBinding.instance.scheduleFrame();
     }
   }
 
@@ -1291,7 +1283,17 @@ class WebFController {
 
     _isComplete = true;
 
+    _dispatchDOMContentLoadedEvent();
     _dispatchWindowLoadEvent();
+  }
+
+  void _dispatchDOMContentLoadedEvent() {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      Event event = Event(EVENT_DOM_CONTENT_LOADED);
+      EventTarget window = view.window;
+      window.dispatchEvent(event);
+      _view.document.dispatchEvent(event);
+    });
   }
 
   void _dispatchWindowLoadEvent() {


### PR DESCRIPTION
```
The DOMContentLoaded event fires when the HTML document has been completely parsed, and all deferred scripts (<script defer src="…"> and <script type="module">) have downloaded and executed. It doesn't wait for other things like images, subframes, and async scripts to finish loading.
```