### PR TITLE
feat: share HttpClient between multiple WebF pages to keep the exist connection alive.

### DIFF
--- a/webf/lib/src/foundation/http_client.dart
+++ b/webf/lib/src/foundation/http_client.dart
@@ -301,7 +301,7 @@ class _HttpHeaders implements HttpHeaders {
   }
 
   @override
-  bool persistentConnection = false;
+  bool persistentConnection = true;
 
   @override
   int? port = 80;

--- a/webf/lib/src/foundation/http_client_response.dart
+++ b/webf/lib/src/foundation/http_client_response.dart
@@ -69,7 +69,7 @@ class HttpClientStreamResponse extends Stream<List<int>> implements HttpClientRe
   bool get isRedirect => statusCode >= 300 && statusCode < 400;
 
   @override
-  bool get persistentConnection => false;
+  bool get persistentConnection => true;
 
   @override
   Future<HttpClientResponse> redirect([String? method, Uri? url, bool? followLoops]) {

--- a/webf/lib/src/module/fetch.dart
+++ b/webf/lib/src/module/fetch.dart
@@ -22,13 +22,11 @@ class FetchModule extends BaseModule {
 
   @override
   void dispose() {
-    _httpClient?.close(force: true);
-    _httpClient = null;
     _disposed = true;
   }
 
-  HttpClient? _httpClient;
-  HttpClient get httpClient => _httpClient ?? (_httpClient = HttpClient());
+  static final HttpClient _sharedHttpClient = HttpClient()..userAgent = NavigatorModule.getUserAgent();
+  HttpClient get httpClient => _sharedHttpClient;
 
   Uri _resolveUri(String input) {
     final Uri parsedUri = Uri.parse(input);


### PR DESCRIPTION
We should share the HttpClient instance between multiple WebF pages and keep the existing connection alive to avoid establishing a new TCP connection with the same URL every time.