### PR TITLE
fix: it's safe to remove keepAlive() for image element.

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -17,10 +17,12 @@ else ()
   add_definitions(-DENABLE_PROFILE=0)
 endif ()
 
-include(CheckIPOSupported)
-check_ipo_supported(RESULT supported OUTPUT error)
-if( supported )
+if (${CMAKE_BUILD_TYPE} STREQUAL "Release" OR ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT supported OUTPUT error)
+  if( supported )
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+  endif()
 endif()
 
 execute_process(

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -240,11 +240,6 @@ void ScriptWrappable::InitializeQuickJSObject() {
   jsObject_ = JS_NewObjectClass(ctx_, wrapper_type_info->classId);
   JS_SetOpaque(jsObject_, this);
 
-  if (KeepAlive()) {
-    JS_DupValue(ctx_, jsObject_);
-    context_->RegisterActiveScriptWrappers(this);
-  }
-
   // Let our instance into inherit prototype methods.
   JSValue prototype = GetExecutingContext()->contextData()->prototypeForType(wrapper_type_info);
   JS_SetPrototype(ctx_, jsObject_, prototype);

--- a/bridge/core/frame/window_or_worker_global_scope.cc
+++ b/bridge/core/frame/window_or_worker_global_scope.cc
@@ -138,4 +138,8 @@ void WindowOrWorkerGlobalScope::clearInterval(ExecutingContext* context, int32_t
   context->Timers()->forceStopTimeoutById(timerId);
 }
 
+void WindowOrWorkerGlobalScope::__gc__(ExecutingContext* context, ExceptionState& exception) {
+  JS_RunGC(context->GetScriptState()->runtime());
+}
+
 }  // namespace webf

--- a/bridge/core/frame/window_or_worker_global_scope.d.ts
+++ b/bridge/core/frame/window_or_worker_global_scope.d.ts
@@ -10,4 +10,8 @@ declare const clearTimeout: (handle: double) => void;
 // @ts-ignore
 declare const clearInterval: (handle: double) => void;
 
+// @ts-ignore
+
+declare const __gc__: () => void;
+
 

--- a/bridge/core/frame/window_or_worker_global_scope.h
+++ b/bridge/core/frame/window_or_worker_global_scope.h
@@ -25,6 +25,7 @@ class WindowOrWorkerGlobalScope {
   static int setInterval(ExecutingContext* context, std::shared_ptr<QJSFunction> handler, ExceptionState& exception);
   static void clearTimeout(ExecutingContext* context, int32_t timerId, ExceptionState& exception);
   static void clearInterval(ExecutingContext* context, int32_t timerId, ExceptionState& exception);
+  static void __gc__(ExecutingContext* context, ExceptionState& exception);
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_image_element.cc
+++ b/bridge/core/html/html_image_element.cc
@@ -14,14 +14,4 @@ bool HTMLImageElement::IsAttributeDefinedInternal(const AtomicString& key) const
   return QJSHTMLImageElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
 }
 
-ScriptPromise HTMLImageElement::decode(ExceptionState& exception_state) const {
-  exception_state.ThrowException(ctx(), ErrorType::InternalError, "Not implemented.");
-  // @TODO not implemented.
-  return ScriptPromise();
-}
-
-bool HTMLImageElement::KeepAlive() const {
-  return true;
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_image_element.d.ts
+++ b/bridge/core/html/html_image_element.d.ts
@@ -15,6 +15,5 @@ interface HTMLImageElement extends HTMLElement {
     fetchPriority: DartImpl<string>;
     loading: DartImpl<string>;
 
-    decode(): Promise<void>;
     new(): void;
 }

--- a/bridge/core/html/html_image_element.h
+++ b/bridge/core/html/html_image_element.h
@@ -17,6 +17,7 @@ class HTMLImageElement : public HTMLElement {
   explicit HTMLImageElement(Document& document);
 
   bool IsAttributeDefinedInternal(const AtomicString& key) const override;
+
  private:
 };
 

--- a/bridge/core/html/html_image_element.h
+++ b/bridge/core/html/html_image_element.h
@@ -17,11 +17,6 @@ class HTMLImageElement : public HTMLElement {
   explicit HTMLImageElement(Document& document);
 
   bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
-  bool KeepAlive() const override;
-
-  ScriptPromise decode(ExceptionState& exception_state) const;
-
  private:
 };
 


### PR DESCRIPTION
In previous version of webf (<= 0.12.0), `nativeBindingObject` are freed at C++ side, it may cause crash when ImageElement freed at allocated immediatly and dart ImageElement are still dispatch load event to it. So we need to keep ImageElement alive until the load event dispatched. [source](https://github.com/openwebf/webf/blob/0.12.0/bridge/bindings/qjs/dom/elements/image_element.cc#L113)

In webf version >= 0.13.0, `nativeBindingObject` are freed at Dart side, so it's safe to just remove the keepAlive() and let it handled by GC.