### PR TITLE
fix: fix memory leaks when send and receive string with dart.

### DIFF
--- a/bridge/bindings/qjs/atomic_string.cc
+++ b/bridge/bindings/qjs/atomic_string.cc
@@ -6,8 +6,8 @@
 #include "atomic_string.h"
 #include <vector>
 #include "built_in_string.h"
-#include "qjs_engine_patch.h"
 #include "foundation/native_string.h"
+#include "qjs_engine_patch.h"
 
 namespace webf {
 
@@ -90,7 +90,7 @@ AtomicString::AtomicString(JSContext* ctx, const std::unique_ptr<AutoFreeNativeS
     : runtime_(JS_GetRuntime(ctx)),
       atom_(JS_NewUnicodeAtom(ctx, native_string->string(), native_string->length())),
       kind_(GetStringKind(native_string.get())),
-      length_(native_string->length()) {};
+      length_(native_string->length()){};
 
 AtomicString::AtomicString(JSContext* ctx, JSValue value)
     : runtime_(JS_GetRuntime(ctx)), atom_(JS_ValueToAtom(ctx, value)) {

--- a/bridge/bindings/qjs/atomic_string.h
+++ b/bridge/bindings/qjs/atomic_string.h
@@ -36,12 +36,11 @@ class AtomicString {
 
   static AtomicString Empty();
   static AtomicString Null();
-  static AtomicString From(JSContext* ctx, NativeString* native_string);
 
   AtomicString() = default;
   AtomicString(JSContext* ctx, const std::string& string);
   AtomicString(JSContext* ctx, const char* str, size_t length);
-  AtomicString(JSContext* ctx, const NativeString* native_string);
+  AtomicString(JSContext* ctx, const std::unique_ptr<AutoFreeNativeString>& native_string);
   AtomicString(JSContext* ctx, const uint16_t* str, size_t length);
   AtomicString(JSContext* ctx, JSValue value);
   AtomicString(JSContext* ctx, JSAtom atom);
@@ -72,7 +71,7 @@ class AtomicString {
   int Find(bool (*CharacterMatchFunction)(uint16_t)) const;
 
   [[nodiscard]] std::string ToStdString(JSContext* ctx) const;
-  [[nodiscard]] std::unique_ptr<NativeString> ToNativeString(JSContext* ctx) const;
+  [[nodiscard]] std::unique_ptr<SharedNativeString> ToNativeString(JSContext* ctx) const;
 
   StringView ToStringView() const;
 

--- a/bridge/bindings/qjs/atomic_string_test.cc
+++ b/bridge/bindings/qjs/atomic_string_test.cc
@@ -40,7 +40,7 @@ TEST(AtomicString, Empty) {
 TEST(AtomicString, FromNativeString) {
   TestAtomicString([](JSContext* ctx) {
     auto nativeString = stringToNativeString("helloworld");
-    AtomicString value = AtomicString::From(ctx, nativeString.get());
+    AtomicString value = AtomicString(ctx, std::make_unique<AutoFreeNativeString>(nativeString.get()));
 
     EXPECT_STREQ(value.ToStdString(ctx).c_str(), "helloworld");
   });

--- a/bridge/bindings/qjs/converter_impl.h
+++ b/bridge/bindings/qjs/converter_impl.h
@@ -213,10 +213,10 @@ struct Converter<IDLDOMString> : public ConverterBase<IDLDOMString> {
   }
 
   static JSValue ToValue(JSContext* ctx, const AtomicString& value) { return value.ToQuickJS(ctx); }
-  static JSValue ToValue(JSContext* ctx, NativeString* str) {
+  static JSValue ToValue(JSContext* ctx, SharedNativeString* str) {
     return JS_NewUnicodeString(ctx, str->string(), str->length());
   }
-  static JSValue ToValue(JSContext* ctx, std::unique_ptr<NativeString> str) {
+  static JSValue ToValue(JSContext* ctx, std::unique_ptr<SharedNativeString> str) {
     return JS_NewUnicodeString(ctx, str->string(), str->length());
   }
   static JSValue ToValue(JSContext* ctx, uint16_t* bytes, size_t length) {

--- a/bridge/bindings/qjs/idl_type.h
+++ b/bridge/bindings/qjs/idl_type.h
@@ -44,7 +44,7 @@ struct IDLInt64 final : public IDLTypeBaseHelper<int32_t> {};
 struct IDLUint32 final : public IDLTypeBaseHelper<uint32_t> {};
 struct IDLDouble final : public IDLTypeBaseHelper<double> {};
 
-class NativeString;
+class SharedNativeString;
 // DOMString is UTF-16 strings.
 // https://stackoverflow.com/questions/35123890/what-is-a-domstring-really
 struct IDLDOMString final : public IDLTypeBaseHelper<AtomicString> {};

--- a/bridge/bindings/qjs/native_string_utils.h
+++ b/bridge/bindings/qjs/native_string_utils.h
@@ -17,12 +17,12 @@
 namespace webf {
 
 // Convert to string and return a full copy of NativeString from JSValue.
-std::unique_ptr<NativeString> jsValueToNativeString(JSContext* ctx, JSValue value);
+std::unique_ptr<SharedNativeString> jsValueToNativeString(JSContext* ctx, JSValue value);
 
 // Encode utf-8 to utf-16, and return a full copy of NativeString.
-std::unique_ptr<NativeString> stringToNativeString(const std::string& string);
+std::unique_ptr<SharedNativeString> stringToNativeString(const std::string& string);
 
-std::string nativeStringToStdString(const NativeString* native_string);
+std::string nativeStringToStdString(const SharedNativeString* native_string);
 
 template <typename T>
 std::string toUTF8(const std::basic_string<T, std::char_traits<T>, std::allocator<T>>& source) {

--- a/bridge/bindings/qjs/script_value.cc
+++ b/bridge/bindings/qjs/script_value.cc
@@ -19,7 +19,7 @@ namespace webf {
 static JSValue FromNativeValue(ExecutingContext* context, const NativeValue& native_value) {
   switch (native_value.tag) {
     case NativeTag::TAG_STRING: {
-      auto* string = static_cast<NativeString*>(native_value.u.ptr);
+      auto* string = static_cast<SharedNativeString*>(native_value.u.ptr);
       if (string == nullptr)
         return JS_NULL;
       JSValue returnedValue = JS_NewUnicodeString(context->ctx(), string->string(), string->length());
@@ -143,7 +143,7 @@ AtomicString ScriptValue::ToString() const {
   return {ctx_, value_};
 }
 
-std::unique_ptr<NativeString> ScriptValue::ToNativeString() const {
+std::unique_ptr<SharedNativeString> ScriptValue::ToNativeString() const {
   return ToString().ToNativeString(ctx_);
 }
 

--- a/bridge/bindings/qjs/script_value.h
+++ b/bridge/bindings/qjs/script_value.h
@@ -38,7 +38,7 @@ class ScriptValue final {
   // Wrap an Quickjs JSValue to ScriptValue.
   explicit ScriptValue(JSContext* ctx, JSValue value)
       : ctx_(ctx), value_(JS_DupValue(ctx, value)), runtime_(JS_GetRuntime(ctx)){};
-  explicit ScriptValue(JSContext* ctx, const NativeString* string)
+  explicit ScriptValue(JSContext* ctx, const SharedNativeString* string)
       : ctx_(ctx), value_(JS_NewUnicodeString(ctx, string->string(), string->length())), runtime_(JS_GetRuntime(ctx)) {}
   explicit ScriptValue(JSContext* ctx, double v)
       : ctx_(ctx), value_(JS_NewFloat64(ctx, v)), runtime_(JS_GetRuntime(ctx)) {}
@@ -60,7 +60,7 @@ class ScriptValue final {
   // Create a new ScriptValue from call JSON.stringify to current value.
   ScriptValue ToJSONStringify(ExceptionState* exception) const;
   AtomicString ToString() const;
-  std::unique_ptr<NativeString> ToNativeString() const;
+  std::unique_ptr<SharedNativeString> ToNativeString() const;
   NativeValue ToNative(ExceptionState& exception_state) const;
 
   bool IsException() const;

--- a/bridge/bindings/qjs/to_quickjs.h
+++ b/bridge/bindings/qjs/to_quickjs.h
@@ -35,10 +35,10 @@ inline JSValue toQuickJS(JSContext* ctx, const std::string& str) {
 inline JSValue toQuickJS(JSContext* ctx, const char* str) {
   return JS_NewString(ctx, str);
 }
-inline JSValue toQuickJS(JSContext* ctx, std::unique_ptr<NativeString>& str) {
+inline JSValue toQuickJS(JSContext* ctx, std::unique_ptr<SharedNativeString>& str) {
   return JS_NewUnicodeString(ctx, str->string(), str->length());
 }
-inline JSValue toQuickJS(JSContext* ctx, NativeString* str) {
+inline JSValue toQuickJS(JSContext* ctx, SharedNativeString* str) {
   return JS_NewUnicodeString(ctx, str->string(), str->length());
 }
 

--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -19,7 +19,8 @@ void NativeBindingObject::HandleCallFromDartSide(NativeBindingObject* binding_ob
                                                  NativeValue* native_method,
                                                  int32_t argc,
                                                  NativeValue* argv) {
-  AtomicString method = AtomicString(binding_object->binding_target_->ctx(), std::make_unique<AutoFreeNativeString>(native_method->u.ptr));
+  AtomicString method = AtomicString(binding_object->binding_target_->ctx(),
+                                     std::make_unique<AutoFreeNativeString>(native_method->u.ptr));
   NativeValue result = binding_object->binding_target_->HandleCallFromDartSide(method, argc, argv);
   if (return_value != nullptr)
     *return_value = result;
@@ -34,8 +35,7 @@ BindingObject::~BindingObject() {
   binding_object_->invoke_bindings_methods_from_native = nullptr;
 }
 
-BindingObject::BindingObject(JSContext* ctx, NativeBindingObject* native_binding_object)
-    : ScriptWrappable(ctx) {
+BindingObject::BindingObject(JSContext* ctx, NativeBindingObject* native_binding_object) : ScriptWrappable(ctx) {
   native_binding_object->binding_target_ = this;
   native_binding_object->invoke_binding_methods_from_dart = NativeBindingObject::HandleCallFromDartSide;
   binding_object_ = native_binding_object;
@@ -49,7 +49,7 @@ void BindingObject::FullFillPendingPromise(BindingObjectPromiseContext* binding_
   pending_promise_contexts_.erase(binding_object_promise_context);
 }
 
-NativeValue BindingObject::HandleCallFromDartSide(const AtomicString &method, int32_t argc, const NativeValue *argv) {
+NativeValue BindingObject::HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) {
   return Native_NewNull();
 }
 
@@ -59,13 +59,14 @@ NativeValue BindingObject::InvokeBindingMethod(const AtomicString& method,
                                                ExceptionState& exception_state) const {
   GetExecutingContext()->FlushUICommand();
   if (binding_object_->invoke_bindings_methods_from_native == nullptr) {
-    exception_state.ThrowException( GetExecutingContext()->ctx(), ErrorType::InternalError,
+    exception_state.ThrowException(GetExecutingContext()->ctx(), ErrorType::InternalError,
                                    "Failed to call dart method: invoke_bindings_methods_from_native not initialized.");
     return Native_NewNull();
   }
 
   NativeValue return_value = Native_NewNull();
-  NativeValue native_method = NativeValueConverter<NativeTypeString>::ToNativeValue( GetExecutingContext()->ctx(), method);
+  NativeValue native_method =
+      NativeValueConverter<NativeTypeString>::ToNativeValue(GetExecutingContext()->ctx(), method);
   binding_object_->invoke_bindings_methods_from_native(binding_object_, &return_value, &native_method, argc, argv);
   return return_value;
 }
@@ -76,7 +77,7 @@ NativeValue BindingObject::InvokeBindingMethod(BindingMethodCallOperations bindi
                                                ExceptionState& exception_state) const {
   GetExecutingContext()->FlushUICommand();
   if (binding_object_->invoke_bindings_methods_from_native == nullptr) {
-    exception_state.ThrowException( GetExecutingContext()->ctx(), ErrorType::InternalError,
+    exception_state.ThrowException(GetExecutingContext()->ctx(), ErrorType::InternalError,
                                    "Failed to call dart method: invoke_bindings_methods_from_native not initialized.");
     return Native_NewNull();
   }
@@ -89,7 +90,7 @@ NativeValue BindingObject::InvokeBindingMethod(BindingMethodCallOperations bindi
 
 NativeValue BindingObject::GetBindingProperty(const AtomicString& prop, ExceptionState& exception_state) const {
   GetExecutingContext()->FlushUICommand();
-  const NativeValue argv[] = {Native_NewString(prop.ToNativeString( GetExecutingContext()->ctx()).release())};
+  const NativeValue argv[] = {Native_NewString(prop.ToNativeString(GetExecutingContext()->ctx()).release())};
   return InvokeBindingMethod(BindingMethodCallOperations::kGetProperty, 1, argv, exception_state);
 }
 
@@ -97,7 +98,7 @@ NativeValue BindingObject::SetBindingProperty(const AtomicString& prop,
                                               NativeValue value,
                                               ExceptionState& exception_state) const {
   GetExecutingContext()->FlushUICommand();
-  const NativeValue argv[] = {Native_NewString(prop.ToNativeString( GetExecutingContext()->ctx()).release()), value};
+  const NativeValue argv[] = {Native_NewString(prop.ToNativeString(GetExecutingContext()->ctx()).release()), value};
   return InvokeBindingMethod(BindingMethodCallOperations::kSetProperty, 2, argv, exception_state);
 }
 

--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -9,21 +9,23 @@
 #include "bindings/qjs/script_promise_resolver.h"
 #include "core/dom/events/event_target.h"
 #include "core/executing_context.h"
+#include "foundation/native_string.h"
 #include "foundation/native_value_converter.h"
 
 namespace webf {
 
 void NativeBindingObject::HandleCallFromDartSide(NativeBindingObject* binding_object,
                                                  NativeValue* return_value,
-                                                 NativeValue* method,
+                                                 NativeValue* native_method,
                                                  int32_t argc,
                                                  NativeValue* argv) {
+  AtomicString method = AtomicString(binding_object->binding_target_->ctx(), std::make_unique<AutoFreeNativeString>(native_method->u.ptr));
   NativeValue result = binding_object->binding_target_->HandleCallFromDartSide(method, argc, argv);
   if (return_value != nullptr)
     *return_value = result;
 }
 
-BindingObject::BindingObject(ExecutingContext* context) : context_(context) {}
+BindingObject::BindingObject(JSContext* ctx) : ScriptWrappable(ctx) {}
 BindingObject::~BindingObject() {
   // Set below properties to nullptr to avoid dart callback to native.
   binding_object_->disposed_ = true;
@@ -32,8 +34,8 @@ BindingObject::~BindingObject() {
   binding_object_->invoke_bindings_methods_from_native = nullptr;
 }
 
-BindingObject::BindingObject(ExecutingContext* context, NativeBindingObject* native_binding_object)
-    : context_(context) {
+BindingObject::BindingObject(JSContext* ctx, NativeBindingObject* native_binding_object)
+    : ScriptWrappable(ctx) {
   native_binding_object->binding_target_ = this;
   native_binding_object->invoke_binding_methods_from_dart = NativeBindingObject::HandleCallFromDartSide;
   binding_object_ = native_binding_object;
@@ -47,19 +49,23 @@ void BindingObject::FullFillPendingPromise(BindingObjectPromiseContext* binding_
   pending_promise_contexts_.erase(binding_object_promise_context);
 }
 
+NativeValue BindingObject::HandleCallFromDartSide(const AtomicString &method, int32_t argc, const NativeValue *argv) {
+  return Native_NewNull();
+}
+
 NativeValue BindingObject::InvokeBindingMethod(const AtomicString& method,
                                                int32_t argc,
                                                const NativeValue* argv,
                                                ExceptionState& exception_state) const {
-  context_->FlushUICommand();
+  GetExecutingContext()->FlushUICommand();
   if (binding_object_->invoke_bindings_methods_from_native == nullptr) {
-    exception_state.ThrowException(context_->ctx(), ErrorType::InternalError,
+    exception_state.ThrowException( GetExecutingContext()->ctx(), ErrorType::InternalError,
                                    "Failed to call dart method: invoke_bindings_methods_from_native not initialized.");
     return Native_NewNull();
   }
 
   NativeValue return_value = Native_NewNull();
-  NativeValue native_method = NativeValueConverter<NativeTypeString>::ToNativeValue(context_->ctx(), method);
+  NativeValue native_method = NativeValueConverter<NativeTypeString>::ToNativeValue( GetExecutingContext()->ctx(), method);
   binding_object_->invoke_bindings_methods_from_native(binding_object_, &return_value, &native_method, argc, argv);
   return return_value;
 }
@@ -68,9 +74,9 @@ NativeValue BindingObject::InvokeBindingMethod(BindingMethodCallOperations bindi
                                                size_t argc,
                                                const NativeValue* argv,
                                                ExceptionState& exception_state) const {
-  context_->FlushUICommand();
+  GetExecutingContext()->FlushUICommand();
   if (binding_object_->invoke_bindings_methods_from_native == nullptr) {
-    exception_state.ThrowException(context_->ctx(), ErrorType::InternalError,
+    exception_state.ThrowException( GetExecutingContext()->ctx(), ErrorType::InternalError,
                                    "Failed to call dart method: invoke_bindings_methods_from_native not initialized.");
     return Native_NewNull();
   }
@@ -82,16 +88,16 @@ NativeValue BindingObject::InvokeBindingMethod(BindingMethodCallOperations bindi
 }
 
 NativeValue BindingObject::GetBindingProperty(const AtomicString& prop, ExceptionState& exception_state) const {
-  context_->FlushUICommand();
-  const NativeValue argv[] = {Native_NewString(prop.ToNativeString(context_->ctx()).release())};
+  GetExecutingContext()->FlushUICommand();
+  const NativeValue argv[] = {Native_NewString(prop.ToNativeString( GetExecutingContext()->ctx()).release())};
   return InvokeBindingMethod(BindingMethodCallOperations::kGetProperty, 1, argv, exception_state);
 }
 
 NativeValue BindingObject::SetBindingProperty(const AtomicString& prop,
                                               NativeValue value,
                                               ExceptionState& exception_state) const {
-  context_->FlushUICommand();
-  const NativeValue argv[] = {Native_NewString(prop.ToNativeString(context_->ctx()).release()), value};
+  GetExecutingContext()->FlushUICommand();
+  const NativeValue argv[] = {Native_NewString(prop.ToNativeString( GetExecutingContext()->ctx()).release()), value};
   return InvokeBindingMethod(BindingMethodCallOperations::kSetProperty, 2, argv, exception_state);
 }
 
@@ -199,7 +205,7 @@ ScriptValue BindingObject::AnonymousAsyncFunctionCallback(JSContext* ctx,
 }
 
 NativeValue BindingObject::GetAllBindingPropertyNames(ExceptionState& exception_state) const {
-  context_->FlushUICommand();
+  GetExecutingContext()->FlushUICommand();
   return InvokeBindingMethod(BindingMethodCallOperations::kGetAllPropertyNames, 0, nullptr, exception_state);
 }
 

--- a/bridge/core/binding_object.h
+++ b/bridge/core/binding_object.h
@@ -9,6 +9,7 @@
 #include <cinttypes>
 #include <set>
 #include "bindings/qjs/atomic_string.h"
+#include "bindings/qjs/script_wrappable.h"
 #include "foundation/native_type.h"
 #include "foundation/native_value.h"
 
@@ -65,7 +66,7 @@ struct BindingObjectPromiseContext : public DartReadable {
   std::shared_ptr<ScriptPromiseResolver> promise_resolver;
 };
 
-class BindingObject {
+class BindingObject : public ScriptWrappable {
  public:
   struct AnonymousFunctionData {
     std::string method_name;
@@ -89,10 +90,10 @@ class BindingObject {
 
   BindingObject() = delete;
   ~BindingObject();
-  explicit BindingObject(ExecutingContext* context);
+  explicit BindingObject(JSContext* ctx);
 
   // Handle call from dart side.
-  virtual NativeValue HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) = 0;
+  virtual NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv);
   // Invoke methods which implemented at dart side.
   NativeValue InvokeBindingMethod(const AtomicString& method,
                                   int32_t argc,
@@ -127,10 +128,9 @@ class BindingObject {
                                   ExceptionState& exception_state) const;
 
   // NativeBindingObject may allocated at Dart side. Binding this with Dart allocated NativeBindingObject.
-  explicit BindingObject(ExecutingContext* context, NativeBindingObject* native_binding_object);
+  explicit BindingObject(JSContext* ctx, NativeBindingObject* native_binding_object);
 
  private:
-  ExecutingContext* context_{nullptr};
   NativeBindingObject* binding_object_{new NativeBindingObject(this)};
   std::set<BindingObjectPromiseContext*> pending_promise_contexts_;
 };

--- a/bridge/core/css/computed_css_style_declaration.cc
+++ b/bridge/core/css/computed_css_style_declaration.cc
@@ -4,8 +4,8 @@
 
 #include "computed_css_style_declaration.h"
 #include "binding_call_methods.h"
-#include "core/dom/element.h"
 #include "core/binding_object.h"
+#include "core/dom/element.h"
 #include "foundation/native_value_converter.h"
 
 namespace webf {

--- a/bridge/core/css/computed_css_style_declaration.cc
+++ b/bridge/core/css/computed_css_style_declaration.cc
@@ -5,19 +5,20 @@
 #include "computed_css_style_declaration.h"
 #include "binding_call_methods.h"
 #include "core/dom/element.h"
+#include "core/binding_object.h"
 #include "foundation/native_value_converter.h"
 
 namespace webf {
 
 ComputedCssStyleDeclaration::ComputedCssStyleDeclaration(ExecutingContext* context,
                                                          NativeBindingObject* native_binding_object)
-    : CSSStyleDeclaration(context->ctx()), BindingObject(context, native_binding_object) {}
+    : CSSStyleDeclaration(context->ctx(), native_binding_object) {}
 
 AtomicString ComputedCssStyleDeclaration::item(const AtomicString& key, ExceptionState& exception_state) {
   NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), key)};
 
   NativeValue result = InvokeBindingMethod(binding_call_methods::kgetPropertyValue, 1, arguments, exception_state);
-  return NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), result);
+  return NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), std::move(result));
 }
 
 bool ComputedCssStyleDeclaration::SetItem(const AtomicString& key,
@@ -47,7 +48,7 @@ void ComputedCssStyleDeclaration::setProperty(const AtomicString& key,
 AtomicString ComputedCssStyleDeclaration::removeProperty(const AtomicString& key, ExceptionState& exception_state) {
   NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), key)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kremoveProperty, 1, arguments, exception_state);
-  return NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), result);
+  return NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), std::move(result));
 }
 
 bool ComputedCssStyleDeclaration::NamedPropertyQuery(const AtomicString& key, ExceptionState& exception_state) {
@@ -67,12 +68,6 @@ void ComputedCssStyleDeclaration::NamedPropertyEnumerator(std::vector<AtomicStri
 
 bool ComputedCssStyleDeclaration::IsComputedCssStyleDeclaration() const {
   return true;
-}
-
-NativeValue ComputedCssStyleDeclaration::HandleCallFromDartSide(const NativeValue* method,
-                                                                int32_t argc,
-                                                                const NativeValue* argv) {
-  return Native_NewNull();
 }
 
 }  // namespace webf

--- a/bridge/core/css/computed_css_style_declaration.h
+++ b/bridge/core/css/computed_css_style_declaration.h
@@ -13,7 +13,7 @@ namespace webf {
 
 class Element;
 
-class ComputedCssStyleDeclaration : public CSSStyleDeclaration, public BindingObject {
+class ComputedCssStyleDeclaration : public CSSStyleDeclaration {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
@@ -34,8 +34,6 @@ class ComputedCssStyleDeclaration : public CSSStyleDeclaration, public BindingOb
   void NamedPropertyEnumerator(std::vector<AtomicString>& names, ExceptionState&) override;
 
   bool IsComputedCssStyleDeclaration() const override;
-
-  NativeValue HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) override;
 
  private:
   Member<Element> owner_element_;

--- a/bridge/core/css/css_style_declaration.cc
+++ b/bridge/core/css/css_style_declaration.cc
@@ -7,6 +7,7 @@
 
 namespace webf {
 
-CSSStyleDeclaration::CSSStyleDeclaration(JSContext* ctx) : ScriptWrappable(ctx) {}
+CSSStyleDeclaration::CSSStyleDeclaration(JSContext* ctx) : BindingObject(ctx) {}
+CSSStyleDeclaration::CSSStyleDeclaration(JSContext *ctx, NativeBindingObject *native_binding_object): BindingObject(ctx, native_binding_object) {}
 
 }  // namespace webf

--- a/bridge/core/css/css_style_declaration.cc
+++ b/bridge/core/css/css_style_declaration.cc
@@ -8,6 +8,7 @@
 namespace webf {
 
 CSSStyleDeclaration::CSSStyleDeclaration(JSContext* ctx) : BindingObject(ctx) {}
-CSSStyleDeclaration::CSSStyleDeclaration(JSContext *ctx, NativeBindingObject *native_binding_object): BindingObject(ctx, native_binding_object) {}
+CSSStyleDeclaration::CSSStyleDeclaration(JSContext* ctx, NativeBindingObject* native_binding_object)
+    : BindingObject(ctx, native_binding_object) {}
 
 }  // namespace webf

--- a/bridge/core/css/css_style_declaration.h
+++ b/bridge/core/css/css_style_declaration.h
@@ -13,6 +13,7 @@ namespace webf {
 
 class CSSStyleDeclaration : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
+
  public:
   using ImplType = CSSStyleDeclaration*;
   explicit CSSStyleDeclaration(JSContext* ctx);

--- a/bridge/core/css/css_style_declaration.h
+++ b/bridge/core/css/css_style_declaration.h
@@ -7,15 +7,16 @@
 #define WEBF_CORE_CSS_CSS_STYLE_DECLARATION_H_
 
 #include "bindings/qjs/script_wrappable.h"
+#include "core/binding_object.h"
 
 namespace webf {
 
-class CSSStyleDeclaration : public ScriptWrappable {
+class CSSStyleDeclaration : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
-
  public:
   using ImplType = CSSStyleDeclaration*;
   explicit CSSStyleDeclaration(JSContext* ctx);
+  explicit CSSStyleDeclaration(JSContext* ctx, NativeBindingObject* native_binding_object);
 
   virtual AtomicString item(const AtomicString& key, ExceptionState& exception_state) = 0;
   virtual bool SetItem(const AtomicString& key, const AtomicString& value, ExceptionState& exception_state) = 0;

--- a/bridge/core/css/inline_css_style_declaration.cc
+++ b/bridge/core/css/inline_css_style_declaration.cc
@@ -151,8 +151,8 @@ bool InlineCssStyleDeclaration::InternalSetProperty(std::string& name, const Ato
 
   properties_[name] = value;
 
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(name);
-  std::unique_ptr<NativeString> args_02 = value.ToNativeString(ctx());
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(name);
+  std::unique_ptr<SharedNativeString> args_02 = value.ToNativeString(ctx());
   GetExecutingContext()->uiCommandBuffer()->addCommand(owner_element_target_id_, UICommand::kSetStyle,
                                                        std::move(args_01), std::move(args_02), nullptr);
 
@@ -169,8 +169,8 @@ AtomicString InlineCssStyleDeclaration::InternalRemoveProperty(std::string& name
   AtomicString return_value = properties_[name];
   properties_.erase(name);
 
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(name);
-  std::unique_ptr<NativeString> args_02 = jsValueToNativeString(ctx(), JS_NULL);
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(name);
+  std::unique_ptr<SharedNativeString> args_02 = jsValueToNativeString(ctx(), JS_NULL);
   GetExecutingContext()->uiCommandBuffer()->addCommand(owner_element_target_id_, UICommand::kSetStyle,
                                                        std::move(args_01), std::move(args_02), nullptr);
 

--- a/bridge/core/css/inline_css_style_declaration_test.cc
+++ b/bridge/core/css/inline_css_style_declaration_test.cc
@@ -61,7 +61,10 @@ document.body.style.setProperty('--main-color', 'lightblue'); console.assert(doc
   uint16_t* last_key = (uint16_t*)last.string_01;
 
   auto native_str = new SharedNativeString(last_key, last.args_01_length);
-  EXPECT_STREQ(AtomicString(context->ctx(), std::make_unique<AutoFreeNativeString>(native_str)).ToStdString(context->ctx()).c_str(), "--main-color");
+  EXPECT_STREQ(AtomicString(context->ctx(), std::make_unique<AutoFreeNativeString>(native_str))
+                   .ToStdString(context->ctx())
+                   .c_str(),
+               "--main-color");
 
   EXPECT_EQ(errorCalled, false);
 }

--- a/bridge/core/css/inline_css_style_declaration_test.cc
+++ b/bridge/core/css/inline_css_style_declaration_test.cc
@@ -60,8 +60,8 @@ document.body.style.setProperty('--main-color', 'lightblue'); console.assert(doc
   EXPECT_EQ(last.type, (int32_t)UICommand::kSetStyle);
   uint16_t* last_key = (uint16_t*)last.string_01;
 
-  auto native_str = NativeString(last_key, last.args_01_length);
-  EXPECT_STREQ(AtomicString(context->ctx(), &native_str).ToStdString(context->ctx()).c_str(), "--main-color");
+  auto native_str = new SharedNativeString(last_key, last.args_01_length);
+  EXPECT_STREQ(AtomicString(context->ctx(), std::make_unique<AutoFreeNativeString>(native_str)).ToStdString(context->ctx()).c_str(), "--main-color");
 
   EXPECT_EQ(errorCalled, false);
 }

--- a/bridge/core/dart_methods.h
+++ b/bridge/core/dart_methods.h
@@ -28,8 +28,8 @@ using AsyncBlobCallback =
     void (*)(void* callback_context, int32_t context_id, const char* error, uint8_t* bytes, int32_t length);
 typedef NativeValue* (*InvokeModule)(void* callback_context,
                                      int32_t context_id,
-                                     NativeString* moduleName,
-                                     NativeString* method,
+                                     SharedNativeString* moduleName,
+                                     SharedNativeString* method,
                                      NativeValue* params,
                                      AsyncModuleCallback callback);
 typedef void (*RequestBatchUpdate)(int32_t context_id);
@@ -55,7 +55,7 @@ using MatchImageSnapshot = void (*)(void* callback_context,
                                     int32_t context_id,
                                     uint8_t* bytes,
                                     int32_t length,
-                                    NativeString* name,
+                                    SharedNativeString* name,
                                     MatchImageSnapshotCallback callback);
 using Environment = const char* (*)();
 
@@ -78,7 +78,7 @@ struct MousePointer {
 };
 using SimulatePointer =
     void (*)(void* ptr, MousePointer*, int32_t length, int32_t pointer, AsyncCallback async_callback);
-using SimulateInputText = void (*)(NativeString* nativeString);
+using SimulateInputText = void (*)(SharedNativeString* nativeString);
 
 struct DartMethodPointer {
   DartMethodPointer() = delete;

--- a/bridge/core/dom/character_data.cc
+++ b/bridge/core/dom/character_data.cc
@@ -13,8 +13,8 @@ namespace webf {
 void CharacterData::setData(const AtomicString& data, ExceptionState& exception_state) {
   data_ = data;
 
-  std::unique_ptr<NativeString> args_01 = stringToNativeString("data");
-  std::unique_ptr<NativeString> args_02 = data.ToNativeString(ctx());
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString("data");
+  std::unique_ptr<SharedNativeString> args_02 = data.ToNativeString(ctx());
 
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kSetAttribute, std::move(args_01),
                                                        std::move(args_02), (void*)bindingObject());

--- a/bridge/core/dom/comment.cc
+++ b/bridge/core/dom/comment.cc
@@ -33,7 +33,7 @@ std::string Comment::nodeName() const {
 
 Node* Comment::Clone(Document& factory, CloneChildrenFlag flag) const {
   Node* copy = Create(factory, data());
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(std::to_string(copy->eventTargetId()));
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(std::to_string(copy->eventTargetId()));
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kCloneNode, std::move(args_01),
                                                        nullptr);
   return copy;

--- a/bridge/core/dom/container_node.cc
+++ b/bridge/core/dom/container_node.cc
@@ -415,8 +415,8 @@ void ContainerNode::InsertBeforeCommon(Node& next_child, Node& new_child) {
   new_child.SetPreviousSibling(prev);
   new_child.SetNextSibling(&next_child);
 
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(std::to_string(new_child.eventTargetId()));
-  std::unique_ptr<NativeString> args_02 = stringToNativeString("beforebegin");
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(std::to_string(new_child.eventTargetId()));
+  std::unique_ptr<SharedNativeString> args_02 = stringToNativeString("beforebegin");
   GetExecutingContext()->uiCommandBuffer()->addCommand(next_child.eventTargetId(), UICommand::kInsertAdjacentNode,
                                                        std::move(args_01), std::move(args_02), nullptr);
 }
@@ -431,8 +431,8 @@ void ContainerNode::AppendChildCommon(Node& child) {
   }
   SetLastChild(&child);
 
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(std::to_string(child.eventTargetId()));
-  std::unique_ptr<NativeString> args_02 = stringToNativeString("beforeend");
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(std::to_string(child.eventTargetId()));
+  std::unique_ptr<SharedNativeString> args_02 = stringToNativeString("beforeend");
 
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kInsertAdjacentNode,
                                                        std::move(args_01), std::move(args_02), nullptr);

--- a/bridge/core/dom/document_fragment.cc
+++ b/bridge/core/dom/document_fragment.cc
@@ -37,7 +37,7 @@ Node* DocumentFragment::Clone(Document& factory, CloneChildrenFlag flag) const {
   DocumentFragment* clone = Create(factory);
   if (flag != CloneChildrenFlag::kSkip)
     clone->CloneChildNodesFrom(*this, flag);
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(std::to_string(clone->eventTargetId()));
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(std::to_string(clone->eventTargetId()));
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kCloneNode, std::move(args_01),
                                                        nullptr);
   return clone;

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -300,7 +300,7 @@ Node* Element::Clone(Document& factory, CloneChildrenFlag flag) const {
     copy = &CloneWithChildren(flag, &factory);
   }
 
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(std::to_string(copy->eventTargetId()));
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(std::to_string(copy->eventTargetId()));
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kCloneNode, std::move(args_01),
                                                        nullptr);
 

--- a/bridge/core/dom/events/event.h
+++ b/bridge/core/dom/events/event.h
@@ -39,7 +39,7 @@ struct NativeEvent {
 // Use pointer instead of int64_t on 64 bit system can help compiler to choose best register for better running
 // performance.
 struct NativeEvent {
-  NativeString* type{nullptr};
+  SharedNativeString* type{nullptr};
   int64_t bubbles{0};
   int64_t cancelable{0};
   int64_t composed{0};

--- a/bridge/core/dom/events/event_target.cc
+++ b/bridge/core/dom/events/event_target.cc
@@ -60,11 +60,10 @@ EventTarget::~EventTarget() {
 }
 
 EventTarget::EventTarget(ExecutingContext* context)
-    : BindingObject(context), ScriptWrappable(context->ctx()), event_target_id_(global_event_target_id++) {}
+    : BindingObject(context->ctx()), event_target_id_(global_event_target_id++) {}
 
 EventTarget::EventTarget(ExecutingContext* context, NativeBindingObject* native_binding_object)
-    : BindingObject(context, native_binding_object),
-      ScriptWrappable(context->ctx()),
+    : BindingObject(context->ctx(), native_binding_object),
       event_target_id_(global_event_target_id++) {}
 
 Node* EventTarget::ToNode() {
@@ -279,11 +278,10 @@ DispatchEventResult EventTarget::DispatchEventInternal(Event& event, ExceptionSt
   return dispatch_result;
 }
 
-NativeValue EventTarget::HandleCallFromDartSide(const NativeValue* native_method,
+NativeValue EventTarget::HandleCallFromDartSide(const AtomicString& method,
                                                 int32_t argc,
                                                 const NativeValue* argv) {
   MemberMutationScope mutation_scope{GetExecutingContext()};
-  AtomicString method = NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), *native_method);
 
   if (method == binding_call_methods::kdispatchEvent) {
     return HandleDispatchEventFromDart(argc, argv);
@@ -294,7 +292,8 @@ NativeValue EventTarget::HandleCallFromDartSide(const NativeValue* native_method
 
 NativeValue EventTarget::HandleDispatchEventFromDart(int32_t argc, const NativeValue* argv) {
   assert(argc == 2);
-  AtomicString event_type = NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), argv[0]);
+  NativeValue native_event_type = argv[0];
+  AtomicString event_type = NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), std::move(native_event_type));
   RawEvent* raw_event = NativeValueConverter<NativeTypePointer<RawEvent>>::FromNativeValue(argv[1]);
 
   Event* event = EventFactory::Create(GetExecutingContext(), event_type, raw_event);

--- a/bridge/core/dom/events/event_target.cc
+++ b/bridge/core/dom/events/event_target.cc
@@ -63,8 +63,7 @@ EventTarget::EventTarget(ExecutingContext* context)
     : BindingObject(context->ctx()), event_target_id_(global_event_target_id++) {}
 
 EventTarget::EventTarget(ExecutingContext* context, NativeBindingObject* native_binding_object)
-    : BindingObject(context->ctx(), native_binding_object),
-      event_target_id_(global_event_target_id++) {}
+    : BindingObject(context->ctx(), native_binding_object), event_target_id_(global_event_target_id++) {}
 
 Node* EventTarget::ToNode() {
   return nullptr;
@@ -278,9 +277,7 @@ DispatchEventResult EventTarget::DispatchEventInternal(Event& event, ExceptionSt
   return dispatch_result;
 }
 
-NativeValue EventTarget::HandleCallFromDartSide(const AtomicString& method,
-                                                int32_t argc,
-                                                const NativeValue* argv) {
+NativeValue EventTarget::HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) {
   MemberMutationScope mutation_scope{GetExecutingContext()};
 
   if (method == binding_call_methods::kdispatchEvent) {
@@ -293,7 +290,8 @@ NativeValue EventTarget::HandleCallFromDartSide(const AtomicString& method,
 NativeValue EventTarget::HandleDispatchEventFromDart(int32_t argc, const NativeValue* argv) {
   assert(argc == 2);
   NativeValue native_event_type = argv[0];
-  AtomicString event_type = NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), std::move(native_event_type));
+  AtomicString event_type =
+      NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), std::move(native_event_type));
   RawEvent* raw_event = NativeValueConverter<NativeTypePointer<RawEvent>>::FromNativeValue(argv[1]);
 
   Event* event = EventFactory::Create(GetExecutingContext(), event_type, raw_event);

--- a/bridge/core/dom/events/event_target.h
+++ b/bridge/core/dom/events/event_target.h
@@ -79,7 +79,7 @@ class Node;
 // EventTarget objects allow us to add and remove an event
 // listeners of a specific event type. Each EventTarget object also represents
 // the target to which an event is dispatched when something has occurred.
-class EventTarget : public ScriptWrappable, public BindingObject {
+class EventTarget : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
@@ -135,6 +135,8 @@ class EventTarget : public ScriptWrappable, public BindingObject {
   // Check the attribute is defined in native.
   virtual bool IsAttributeDefinedInternal(const AtomicString& key) const;
 
+  NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
+
   void Trace(GCVisitor* visitor) const override;
 
  protected:
@@ -147,7 +149,6 @@ class EventTarget : public ScriptWrappable, public BindingObject {
 
   DispatchEventResult DispatchEventInternal(Event& event, ExceptionState& exception_state);
 
-  NativeValue HandleCallFromDartSide(const NativeValue* native_method, int32_t argc, const NativeValue* argv) override;
   NativeValue HandleDispatchEventFromDart(int32_t argc, const NativeValue* argv);
 
   // Subclasses should likely not override these themselves; instead, they

--- a/bridge/core/dom/legacy/bounding_client_rect.cc
+++ b/bridge/core/dom/legacy/bounding_client_rect.cc
@@ -13,9 +13,9 @@ BoundingClientRect* BoundingClientRect::Create(ExecutingContext* context, Native
 }
 
 BoundingClientRect::BoundingClientRect(ExecutingContext* context, NativeBindingObject* native_binding_object)
-    : ScriptWrappable(context->ctx()), BindingObject(context, native_binding_object) {}
+    : BindingObject(context->ctx(), native_binding_object) {}
 
-NativeValue BoundingClientRect::HandleCallFromDartSide(const NativeValue* method,
+NativeValue BoundingClientRect::HandleCallFromDartSide(const AtomicString& method,
                                                        int32_t argc,
                                                        const NativeValue* argv) {
   return Native_NewNull();

--- a/bridge/core/dom/legacy/bounding_client_rect.h
+++ b/bridge/core/dom/legacy/bounding_client_rect.h
@@ -14,7 +14,7 @@ namespace webf {
 
 class ExecutingContext;
 
-class BoundingClientRect : public ScriptWrappable, public BindingObject {
+class BoundingClientRect : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
@@ -23,7 +23,7 @@ class BoundingClientRect : public ScriptWrappable, public BindingObject {
   static BoundingClientRect* Create(ExecutingContext* context, NativeBindingObject* native_binding_object);
   explicit BoundingClientRect(ExecutingContext* context, NativeBindingObject* native_binding_object);
 
-  NativeValue HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) override;
+  NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
 
   double x() const { return x_; }
   double y() const { return y_; }

--- a/bridge/core/dom/legacy/element_attributes.cc
+++ b/bridge/core/dom/legacy/element_attributes.cc
@@ -33,7 +33,7 @@ AtomicString ElementAttributes::getAttribute(const AtomicString& name, Exception
   if (value.IsEmpty()) {
     NativeValue dart_result = element_->GetBindingProperty(name, exception_state);
     if (dart_result.tag == NativeTag::TAG_STRING) {
-      return NativeValueConverter<NativeTypeString>::FromNativeValue(element_->ctx(), dart_result);
+      return NativeValueConverter<NativeTypeString>::FromNativeValue(element_->ctx(), std::move(dart_result));
     }
   }
 
@@ -54,8 +54,8 @@ bool ElementAttributes::setAttribute(const AtomicString& name,
 
   attributes_[name] = value;
 
-  std::unique_ptr<NativeString> args_01 = name.ToNativeString(ctx());
-  std::unique_ptr<NativeString> args_02 = value.ToNativeString(ctx());
+  std::unique_ptr<SharedNativeString> args_01 = name.ToNativeString(ctx());
+  std::unique_ptr<SharedNativeString> args_02 = value.ToNativeString(ctx());
 
   GetExecutingContext()->uiCommandBuffer()->addCommand(element_->eventTargetId(), UICommand::kSetAttribute,
                                                        std::move(args_01), std::move(args_02), nullptr);
@@ -76,7 +76,7 @@ bool ElementAttributes::hasAttribute(const AtomicString& name, ExceptionState& e
 void ElementAttributes::removeAttribute(const AtomicString& name, ExceptionState& exception_state) {
   attributes_.erase(name);
 
-  std::unique_ptr<NativeString> args_01 = name.ToNativeString(ctx());
+  std::unique_ptr<SharedNativeString> args_01 = name.ToNativeString(ctx());
   GetExecutingContext()->uiCommandBuffer()->addCommand(element_->eventTargetId(), UICommand::kRemoveAttribute,
                                                        std::move(args_01), nullptr);
 }

--- a/bridge/core/dom/text.cc
+++ b/bridge/core/dom/text.cc
@@ -30,7 +30,7 @@ std::string Text::nodeName() const {
 
 Node* Text::Clone(Document& document, CloneChildrenFlag flag) const {
   Node* copy = Create(document, data());
-  std::unique_ptr<NativeString> args_01 = stringToNativeString(std::to_string(copy->eventTargetId()));
+  std::unique_ptr<SharedNativeString> args_01 = stringToNativeString(std::to_string(copy->eventTargetId()));
   GetExecutingContext()->uiCommandBuffer()->addCommand(eventTargetId(), UICommand::kCloneNode, std::move(args_01),
                                                        nullptr);
   return copy;

--- a/bridge/core/events/close_event.cc
+++ b/bridge/core/events/close_event.cc
@@ -51,7 +51,9 @@ CloseEvent::CloseEvent(ExecutingContext* context, const AtomicString& type, Nati
     : Event(context, type, &native_close_event->native_event),
       code_(native_close_event->code),
 #if ANDROID_32_BIT
-      reason_(AtomicString(context->ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_close_event->reason)))),
+      reason_(AtomicString(
+          context->ctx(),
+          std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_close_event->reason)))),
 #else
       reason_(AtomicString(context->ctx(), std::make_unique<AutoFreeNativeString>(native_close_event->reason))),
 #endif

--- a/bridge/core/events/close_event.cc
+++ b/bridge/core/events/close_event.cc
@@ -51,9 +51,9 @@ CloseEvent::CloseEvent(ExecutingContext* context, const AtomicString& type, Nati
     : Event(context, type, &native_close_event->native_event),
       code_(native_close_event->code),
 #if ANDROID_32_BIT
-      reason_(AtomicString(context->ctx(), reinterpret_cast<NativeString*>(native_close_event->reason))),
+      reason_(AtomicString(context->ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_close_event->reason)))),
 #else
-      reason_(AtomicString(context->ctx(), native_close_event->reason)),
+      reason_(AtomicString(context->ctx(), std::make_unique<AutoFreeNativeString>(native_close_event->reason))),
 #endif
       was_clean_(native_close_event->wasClean) {
 }

--- a/bridge/core/events/gesture_event.cc
+++ b/bridge/core/events/gesture_event.cc
@@ -41,8 +41,12 @@ GestureEvent::GestureEvent(ExecutingContext* context,
                            NativeGestureEvent* native_gesture_event)
     : Event(context, type, &native_gesture_event->native_event),
 #if ANDROID_32_BIT
-      state_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_gesture_event->state)))),
-      direction_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_gesture_event->direction)))),
+      state_(AtomicString(
+          ctx(),
+          std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_gesture_event->state)))),
+      direction_(AtomicString(ctx(),
+                              std::make_unique<AutoFreeNativeString>(
+                                  reinterpret_cast<SharedNativeString*>(native_gesture_event->direction)))),
 #else
       state_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_gesture_event->state))),
       direction_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_gesture_event->direction))),

--- a/bridge/core/events/gesture_event.cc
+++ b/bridge/core/events/gesture_event.cc
@@ -41,11 +41,11 @@ GestureEvent::GestureEvent(ExecutingContext* context,
                            NativeGestureEvent* native_gesture_event)
     : Event(context, type, &native_gesture_event->native_event),
 #if ANDROID_32_BIT
-      state_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_gesture_event->state))),
-      direction_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_gesture_event->direction))),
+      state_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_gesture_event->state)))),
+      direction_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_gesture_event->direction)))),
 #else
-      state_(AtomicString(ctx(), native_gesture_event->state)),
-      direction_(AtomicString(ctx(), native_gesture_event->direction)),
+      state_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_gesture_event->state))),
+      direction_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_gesture_event->direction))),
 #endif
       deltaX_(native_gesture_event->deltaX),
       deltaY_(native_gesture_event->deltaY),

--- a/bridge/core/events/input_event.cc
+++ b/bridge/core/events/input_event.cc
@@ -3,8 +3,8 @@
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
 
-#include <memory>
 #include "input_event.h"
+#include <memory>
 #include "qjs_input_event.h"
 
 namespace webf {
@@ -34,8 +34,12 @@ InputEvent::InputEvent(ExecutingContext* context,
 InputEvent::InputEvent(ExecutingContext* context, const AtomicString& type, NativeInputEvent* native_input_event)
     : UIEvent(context, type, &native_input_event->native_event),
 #if ANDROID_32_BIT
-      input_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_input_event->inputType)))),
-      data_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_input_event->data))))
+      input_type_(AtomicString(ctx(),
+                               std::make_unique<AutoFreeNativeString>(
+                                   reinterpret_cast<SharedNativeString*>(native_input_event->inputType)))),
+      data_(AtomicString(
+          ctx(),
+          std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_input_event->data))))
 #else
       input_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_input_event->inputType))),
       data_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_input_event->data)))

--- a/bridge/core/events/input_event.cc
+++ b/bridge/core/events/input_event.cc
@@ -3,6 +3,7 @@
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
 
+#include <memory>
 #include "input_event.h"
 #include "qjs_input_event.h"
 
@@ -33,11 +34,11 @@ InputEvent::InputEvent(ExecutingContext* context,
 InputEvent::InputEvent(ExecutingContext* context, const AtomicString& type, NativeInputEvent* native_input_event)
     : UIEvent(context, type, &native_input_event->native_event),
 #if ANDROID_32_BIT
-      input_type_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_input_event->inputType))),
-      data_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_input_event->data)))
+      input_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_input_event->inputType)))),
+      data_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_input_event->data))))
 #else
-      input_type_(AtomicString(ctx(), native_input_event->inputType)),
-      data_(AtomicString(ctx(), native_input_event->data))
+      input_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_input_event->inputType))),
+      data_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_input_event->data)))
 #endif
 {
 }

--- a/bridge/core/events/keyboard_event.cc
+++ b/bridge/core/events/keyboard_event.cc
@@ -53,8 +53,12 @@ KeyboardEvent::KeyboardEvent(ExecutingContext* context,
       alt_key_(native_keyboard_event->altKey),
       char_code_(native_keyboard_event->charCode),
 #if ANDROID_32_BIT
-      code_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_keyboard_event->code)))),
-      key_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_keyboard_event->key)))),
+      code_(AtomicString(
+          ctx(),
+          std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_keyboard_event->code)))),
+      key_(AtomicString(
+          ctx(),
+          std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_keyboard_event->key)))),
 #else
       code_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_keyboard_event->code))),
       key_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_keyboard_event->key))),

--- a/bridge/core/events/keyboard_event.cc
+++ b/bridge/core/events/keyboard_event.cc
@@ -53,11 +53,11 @@ KeyboardEvent::KeyboardEvent(ExecutingContext* context,
       alt_key_(native_keyboard_event->altKey),
       char_code_(native_keyboard_event->charCode),
 #if ANDROID_32_BIT
-      code_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_keyboard_event->code))),
-      key_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_keyboard_event->key))),
+      code_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_keyboard_event->code)))),
+      key_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_keyboard_event->key)))),
 #else
-      code_(AtomicString(ctx(), native_keyboard_event->code)),
-      key_(AtomicString(ctx(), native_keyboard_event->key)),
+      code_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_keyboard_event->code))),
+      key_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_keyboard_event->key))),
 #endif
       ctrl_key_(native_keyboard_event->ctrlKey),
       is_composing_(native_keyboard_event->isComposing),

--- a/bridge/core/events/message_event.cc
+++ b/bridge/core/events/message_event.cc
@@ -40,9 +40,15 @@ MessageEvent::MessageEvent(ExecutingContext* context,
     : Event(context, type, &native_message_event->native_event),
 #if ANDROID_32_BIT
       data_(ScriptValue(ctx(), *(reinterpret_cast<NativeValue*>(native_message_event->data)))),
-      origin_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->origin)))),
-      lastEventId_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->lastEventId)))),
-      source_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->source))))
+      origin_(AtomicString(
+          ctx(),
+          std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->origin)))),
+      lastEventId_(AtomicString(ctx(),
+                                std::make_unique<AutoFreeNativeString>(
+                                    reinterpret_cast<SharedNativeString*>(native_message_event->lastEventId)))),
+      source_(AtomicString(
+          ctx(),
+          std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->source))))
 #else
       data_(ScriptValue(ctx(), *(static_cast<NativeValue*>(native_message_event->data)))),
       origin_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_message_event->origin))),

--- a/bridge/core/events/message_event.cc
+++ b/bridge/core/events/message_event.cc
@@ -40,14 +40,14 @@ MessageEvent::MessageEvent(ExecutingContext* context,
     : Event(context, type, &native_message_event->native_event),
 #if ANDROID_32_BIT
       data_(ScriptValue(ctx(), *(reinterpret_cast<NativeValue*>(native_message_event->data)))),
-      origin_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_message_event->origin))),
-      lastEventId_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_message_event->lastEventId))),
-      source_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_message_event->source)))
+      origin_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->origin)))),
+      lastEventId_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->lastEventId)))),
+      source_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_message_event->source))))
 #else
       data_(ScriptValue(ctx(), *(static_cast<NativeValue*>(native_message_event->data)))),
-      origin_(AtomicString(ctx(), native_message_event->origin)),
-      lastEventId_(AtomicString(ctx(), native_message_event->lastEventId)),
-      source_(AtomicString(ctx(), native_message_event->source))
+      origin_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_message_event->origin))),
+      lastEventId_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_message_event->lastEventId))),
+      source_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_message_event->source)))
 #endif
 
 {

--- a/bridge/core/events/pointer_event.cc
+++ b/bridge/core/events/pointer_event.cc
@@ -47,7 +47,9 @@ PointerEvent::PointerEvent(ExecutingContext* context,
       is_primary(native_pointer_event->isPrimary),
       pointer_id_(native_pointer_event->pointerId),
 #if ANDROID_32_BIT
-      pointer_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_pointer_event->pointerType)))),
+      pointer_type_(AtomicString(ctx(),
+                                 std::make_unique<AutoFreeNativeString>(
+                                     reinterpret_cast<SharedNativeString*>(native_pointer_event->pointerType)))),
 #else
       pointer_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_pointer_event->pointerType))),
 #endif

--- a/bridge/core/events/pointer_event.cc
+++ b/bridge/core/events/pointer_event.cc
@@ -47,9 +47,9 @@ PointerEvent::PointerEvent(ExecutingContext* context,
       is_primary(native_pointer_event->isPrimary),
       pointer_id_(native_pointer_event->pointerId),
 #if ANDROID_32_BIT
-      pointer_type_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_pointer_event->pointerType))),
+      pointer_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_pointer_event->pointerType)))),
 #else
-      pointer_type_(AtomicString(ctx(), native_pointer_event->pointerType)),
+      pointer_type_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_pointer_event->pointerType))),
 #endif
       pressure_(native_pointer_event->pressure),
       tangential_pressure_(native_pointer_event->tangentialPressure),

--- a/bridge/core/events/transition_event.cc
+++ b/bridge/core/events/transition_event.cc
@@ -39,11 +39,17 @@ TransitionEvent::TransitionEvent(ExecutingContext* context,
       Event(context, type, &native_transition_event->native_event),
       elapsed_time_(native_transition_event->elapsedTime),
 #if ANDROID_32_BIT
-      property_name_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_transition_event->propertyName)))),
-      pseudo_element_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_transition_event->pseudoElement))))
+      property_name_(AtomicString(ctx(),
+                                  std::make_unique<AutoFreeNativeString>(
+                                      reinterpret_cast<SharedNativeString*>(native_transition_event->propertyName)))),
+      pseudo_element_(AtomicString(ctx(),
+                                   std::make_unique<AutoFreeNativeString>(
+                                       reinterpret_cast<SharedNativeString*>(native_transition_event->pseudoElement))))
 #else
-      property_name_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_transition_event->propertyName))),
-      pseudo_element_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_transition_event->pseudoElement)))
+      property_name_(
+          AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_transition_event->propertyName))),
+      pseudo_element_(
+          AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_transition_event->pseudoElement)))
 #endif
 {
 }

--- a/bridge/core/events/transition_event.cc
+++ b/bridge/core/events/transition_event.cc
@@ -39,11 +39,11 @@ TransitionEvent::TransitionEvent(ExecutingContext* context,
       Event(context, type, &native_transition_event->native_event),
       elapsed_time_(native_transition_event->elapsedTime),
 #if ANDROID_32_BIT
-      property_name_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_transition_event->propertyName))),
-      pseudo_element_(AtomicString(ctx(), reinterpret_cast<NativeString*>(native_transition_event->pseudoElement)))
+      property_name_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_transition_event->propertyName)))),
+      pseudo_element_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(reinterpret_cast<SharedNativeString*>(native_transition_event->pseudoElement))))
 #else
-      property_name_(AtomicString(ctx(), native_transition_event->propertyName)),
-      pseudo_element_(AtomicString(ctx(), native_transition_event->pseudoElement))
+      property_name_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_transition_event->propertyName))),
+      pseudo_element_(AtomicString(ctx(), std::make_unique<AutoFreeNativeString>(native_transition_event->pseudoElement)))
 #endif
 {
 }

--- a/bridge/core/executing_context_test.cc
+++ b/bridge/core/executing_context_test.cc
@@ -42,8 +42,8 @@ TEST(Context, recursionThrowError) {
   auto errorHandler = [](int32_t contextId, const char* errmsg) { errorHandlerExecuted = true; };
   auto bridge = TEST_init(errorHandler);
   const char* code =
-      "addEventListener('error', (evt) => {\n"
-      "  console.log('tagName', evt.target.tagName());\n"
+      "addEventListener('click', (evt) => {\n"
+      "  console.log(1);\n"
       "});\n"
       "\n"
       "throw Error('foo');";
@@ -345,7 +345,7 @@ TEST(Context, evaluateByteCode) {
 TEST(jsValueToNativeString, utf8String) {
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) {});
   JSValue str = JS_NewString(bridge->GetExecutingContext()->ctx(), "helloworld");
-  std::unique_ptr<webf::NativeString> nativeString =
+  std::unique_ptr<webf::SharedNativeString> nativeString =
       webf::jsValueToNativeString(bridge->GetExecutingContext()->ctx(), str);
   EXPECT_EQ(nativeString->length(), 10);
   uint8_t expectedString[10] = {104, 101, 108, 108, 111, 119, 111, 114, 108, 100};
@@ -358,7 +358,7 @@ TEST(jsValueToNativeString, utf8String) {
 TEST(jsValueToNativeString, unicodeChinese) {
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) {});
   JSValue str = JS_NewString(bridge->GetExecutingContext()->ctx(), "这是你的优乐美");
-  std::unique_ptr<webf::NativeString> nativeString =
+  std::unique_ptr<webf::SharedNativeString> nativeString =
       webf::jsValueToNativeString(bridge->GetExecutingContext()->ctx(), str);
   std::u16string expectedString = u"这是你的优乐美";
   EXPECT_EQ(nativeString->length(), expectedString.size());
@@ -371,7 +371,7 @@ TEST(jsValueToNativeString, unicodeChinese) {
 TEST(jsValueToNativeString, emoji) {
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) {});
   JSValue str = JS_NewString(bridge->GetExecutingContext()->ctx(), "……🤪");
-  std::unique_ptr<webf::NativeString> nativeString =
+  std::unique_ptr<webf::SharedNativeString> nativeString =
       webf::jsValueToNativeString(bridge->GetExecutingContext()->ctx(), str);
   std::u16string expectedString = u"……🤪";
   EXPECT_EQ(nativeString->length(), expectedString.length());

--- a/bridge/core/geometry/dom_matrix_readonly.cc
+++ b/bridge/core/geometry/dom_matrix_readonly.cc
@@ -16,7 +16,7 @@ DOMMatrixReadonly* DOMMatrixReadonly::Create(ExecutingContext* context,
 DOMMatrixReadonly::DOMMatrixReadonly(ExecutingContext* context,
                                      const std::shared_ptr<QJSUnionDomStringSequenceDouble>& init,
                                      ExceptionState& exception_state)
-    : BindingObject(context), ScriptWrappable(context->ctx()) {
+    : BindingObject(context->ctx()) {
   assert(GetExecutingContext()->dartMethodPtr()->create_binding_object != nullptr);
 
   NativeValue arguments[1];
@@ -29,7 +29,7 @@ DOMMatrixReadonly::DOMMatrixReadonly(ExecutingContext* context,
       GetExecutingContext()->contextId(), bindingObject(), CreateBindingObjectType::kCreateDOMMatrix, arguments, 1);
 }
 
-NativeValue DOMMatrixReadonly::HandleCallFromDartSide(const NativeValue* method,
+NativeValue DOMMatrixReadonly::HandleCallFromDartSide(const AtomicString& method,
                                                       int32_t argc,
                                                       const NativeValue* argv) {
   return Native_NewNull();

--- a/bridge/core/geometry/dom_matrix_readonly.h
+++ b/bridge/core/geometry/dom_matrix_readonly.h
@@ -11,7 +11,7 @@
 
 namespace webf {
 
-class DOMMatrixReadonly : public ScriptWrappable, public BindingObject {
+class DOMMatrixReadonly : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
@@ -25,7 +25,7 @@ class DOMMatrixReadonly : public ScriptWrappable, public BindingObject {
                              const std::shared_ptr<QJSUnionDomStringSequenceDouble>& init,
                              ExceptionState& exception_state);
 
-  NativeValue HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) override;
+  NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
 };
 
 }  // namespace webf

--- a/bridge/core/html/canvas/canvas_gradient.cc
+++ b/bridge/core/html/canvas/canvas_gradient.cc
@@ -7,9 +7,9 @@
 namespace webf {
 
 CanvasGradient::CanvasGradient(ExecutingContext* context, NativeBindingObject* native_binding_object)
-    : ScriptWrappable(context->ctx()), BindingObject(context, native_binding_object) {}
+    : BindingObject(context->ctx(), native_binding_object) {}
 
-NativeValue CanvasGradient::HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) {
+NativeValue CanvasGradient::HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) {
   return Native_NewNull();
 }
 

--- a/bridge/core/html/canvas/canvas_gradient.h
+++ b/bridge/core/html/canvas/canvas_gradient.h
@@ -10,7 +10,7 @@
 
 namespace webf {
 
-class CanvasGradient : public ScriptWrappable, public BindingObject {
+class CanvasGradient : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
@@ -19,7 +19,7 @@ class CanvasGradient : public ScriptWrappable, public BindingObject {
   CanvasGradient() = delete;
   explicit CanvasGradient(ExecutingContext* context, NativeBindingObject* native_binding_object);
 
-  NativeValue HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) override;
+  NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
 
   bool IsCanvasGradient() const override;
 

--- a/bridge/core/html/canvas/canvas_pattern.cc
+++ b/bridge/core/html/canvas/canvas_pattern.cc
@@ -9,14 +9,14 @@
 namespace webf {
 
 CanvasPattern::CanvasPattern(ExecutingContext* context, NativeBindingObject* native_binding_object)
-    : ScriptWrappable(context->ctx()), BindingObject(context, native_binding_object) {}
+    : BindingObject(context->ctx(), native_binding_object) {}
 
 void CanvasPattern::setTransform(DOMMatrix* dom_matrix, ExceptionState& exception_state) {
   NativeValue arguments[] = {NativeValueConverter<NativeTypePointer<DOMMatrix>>::ToNativeValue(dom_matrix)};
   InvokeBindingMethod(binding_call_methods::ksetTransform, 1, arguments, exception_state);
 }
 
-NativeValue CanvasPattern::HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) {
+NativeValue CanvasPattern::HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) {
   return Native_NewNull();
 }
 

--- a/bridge/core/html/canvas/canvas_pattern.h
+++ b/bridge/core/html/canvas/canvas_pattern.h
@@ -11,7 +11,7 @@
 
 namespace webf {
 
-class CanvasPattern : public ScriptWrappable, public BindingObject {
+class CanvasPattern : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
@@ -22,7 +22,7 @@ class CanvasPattern : public ScriptWrappable, public BindingObject {
 
   void setTransform(DOMMatrix* dom_matrix, ExceptionState& exception_state);
 
-  NativeValue HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) override;
+  NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
 };
 
 }  // namespace webf

--- a/bridge/core/html/canvas/canvas_rendering_context.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context.cc
@@ -7,7 +7,7 @@
 
 namespace webf {
 
-CanvasRenderingContext::CanvasRenderingContext(ExecutingContext* context) : ScriptWrappable(context->ctx()) {}
+CanvasRenderingContext::CanvasRenderingContext(JSContext* ctx, NativeBindingObject* native_binding_object) : BindingObject(ctx, native_binding_object) {}
 
 bool CanvasRenderingContext::IsCanvas2d() const {
   return false;

--- a/bridge/core/html/canvas/canvas_rendering_context.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context.cc
@@ -7,7 +7,8 @@
 
 namespace webf {
 
-CanvasRenderingContext::CanvasRenderingContext(JSContext* ctx, NativeBindingObject* native_binding_object) : BindingObject(ctx, native_binding_object) {}
+CanvasRenderingContext::CanvasRenderingContext(JSContext* ctx, NativeBindingObject* native_binding_object)
+    : BindingObject(ctx, native_binding_object) {}
 
 bool CanvasRenderingContext::IsCanvas2d() const {
   return false;

--- a/bridge/core/html/canvas/canvas_rendering_context.h
+++ b/bridge/core/html/canvas/canvas_rendering_context.h
@@ -10,12 +10,12 @@
 
 namespace webf {
 
-class CanvasRenderingContext : public ScriptWrappable {
+class CanvasRenderingContext : public BindingObject {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
   using ImplType = CanvasRenderingContext*;
-  explicit CanvasRenderingContext(ExecutingContext* context);
+  explicit CanvasRenderingContext(JSContext* ctx, NativeBindingObject* native_binding_object);
 
   virtual bool IsCanvas2d() const;
 

--- a/bridge/core/html/canvas/canvas_rendering_context_2d.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context_2d.cc
@@ -15,9 +15,9 @@ bool CanvasRenderingContext2D::IsCanvas2d() const {
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(ExecutingContext* context,
                                                    NativeBindingObject* native_binding_object)
-    : BindingObject(context, native_binding_object), CanvasRenderingContext(context) {}
+    : CanvasRenderingContext(context->ctx(), native_binding_object) {}
 
-NativeValue CanvasRenderingContext2D::HandleCallFromDartSide(const NativeValue* method,
+NativeValue CanvasRenderingContext2D::HandleCallFromDartSide(const AtomicString& method,
                                                              int32_t argc,
                                                              const NativeValue* argv) {
   return Native_NewNull();
@@ -98,7 +98,7 @@ void CanvasRenderingContext2D::setFillStyle(const std::shared_ptr<QJSUnionDomStr
   }
   SetBindingProperty(binding_call_methods::kfillStyle, value, exception_state);
 
-  fill_style_ = style;
+//  fill_style_ = style;
 }
 
 std::shared_ptr<QJSUnionDomStringCanvasGradient> CanvasRenderingContext2D::strokeStyle() {

--- a/bridge/core/html/canvas/canvas_rendering_context_2d.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context_2d.cc
@@ -98,7 +98,7 @@ void CanvasRenderingContext2D::setFillStyle(const std::shared_ptr<QJSUnionDomStr
   }
   SetBindingProperty(binding_call_methods::kfillStyle, value, exception_state);
 
-//  fill_style_ = style;
+  //  fill_style_ = style;
 }
 
 std::shared_ptr<QJSUnionDomStringCanvasGradient> CanvasRenderingContext2D::strokeStyle() {

--- a/bridge/core/html/canvas/canvas_rendering_context_2d.h
+++ b/bridge/core/html/canvas/canvas_rendering_context_2d.h
@@ -13,7 +13,7 @@
 
 namespace webf {
 
-class CanvasRenderingContext2D : public CanvasRenderingContext, public BindingObject {
+class CanvasRenderingContext2D : public CanvasRenderingContext {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
@@ -21,7 +21,7 @@ class CanvasRenderingContext2D : public CanvasRenderingContext, public BindingOb
   CanvasRenderingContext2D() = delete;
   explicit CanvasRenderingContext2D(ExecutingContext* context, NativeBindingObject* native_binding_object);
 
-  NativeValue HandleCallFromDartSide(const NativeValue* method, int32_t argc, const NativeValue* argv) override;
+  NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
   CanvasGradient* createLinearGradient(double x0,
                                        double y0,
                                        double x1,

--- a/bridge/core/html/custom/widget_element.cc
+++ b/bridge/core/html/custom/widget_element.cc
@@ -42,17 +42,16 @@ void WidgetElement::NamedPropertyEnumerator(std::vector<AtomicString>& names, Ex
   }
 }
 
-NativeValue WidgetElement::HandleCallFromDartSide(const NativeValue* native_method,
+NativeValue WidgetElement::HandleCallFromDartSide(const AtomicString& method,
                                                   int32_t argc,
                                                   const NativeValue* argv) {
   MemberMutationScope mutation_scope{GetExecutingContext()};
-  AtomicString method = NativeValueConverter<NativeTypeString>::FromNativeValue(ctx(), *native_method);
 
   if (method == binding_call_methods::ksyncPropertiesAndMethods) {
     return HandleSyncPropertiesAndMethodsFromDart(argc, argv);
   }
 
-  return Element::HandleCallFromDartSide(native_method, argc, argv);
+  return Element::HandleCallFromDartSide(method, argc, argv);
 }
 
 ScriptValue WidgetElement::item(const AtomicString& key, ExceptionState& exception_state) {

--- a/bridge/core/html/custom/widget_element.cc
+++ b/bridge/core/html/custom/widget_element.cc
@@ -42,9 +42,7 @@ void WidgetElement::NamedPropertyEnumerator(std::vector<AtomicString>& names, Ex
   }
 }
 
-NativeValue WidgetElement::HandleCallFromDartSide(const AtomicString& method,
-                                                  int32_t argc,
-                                                  const NativeValue* argv) {
+NativeValue WidgetElement::HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) {
   MemberMutationScope mutation_scope{GetExecutingContext()};
 
   if (method == binding_call_methods::ksyncPropertiesAndMethods) {

--- a/bridge/core/html/custom/widget_element.h
+++ b/bridge/core/html/custom/widget_element.h
@@ -27,7 +27,7 @@ class WidgetElement : public HTMLElement {
   bool NamedPropertyQuery(const AtomicString& key, ExceptionState& exception_state);
   void NamedPropertyEnumerator(std::vector<AtomicString>& names, ExceptionState&);
 
-  NativeValue HandleCallFromDartSide(const NativeValue* native_method, int32_t argc, const NativeValue* argv) override;
+  NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
 
   ScriptValue item(const AtomicString& key, ExceptionState& exception_state);
   bool SetItem(const AtomicString& key, const ScriptValue& value, ExceptionState& exception_state);

--- a/bridge/core/page.cc
+++ b/bridge/core/page.cc
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <unordered_map>
 
+#include "foundation/native_value_converter.h"
 #include "bindings/qjs/atomic_string.h"
 #include "bindings/qjs/binding_initializer.h"
 #include "core/dart_methods.h"
@@ -50,7 +51,7 @@ bool WebFPage::parseHTML(const char* code, size_t length) {
   return true;
 }
 
-NativeValue* WebFPage::invokeModuleEvent(const NativeString* native_module_name,
+NativeValue* WebFPage::invokeModuleEvent(SharedNativeString* native_module_name,
                                          const char* eventType,
                                          void* ptr,
                                          NativeValue* extra) {
@@ -68,7 +69,7 @@ NativeValue* WebFPage::invokeModuleEvent(const NativeString* native_module_name,
   }
 
   ScriptValue extraObject = ScriptValue(ctx, *extra);
-  AtomicString module_name = AtomicString(ctx, native_module_name);
+  AtomicString module_name = AtomicString(ctx, std::make_unique<AutoFreeNativeString>(native_module_name));
   auto listener = context_->ModuleListeners()->listener(module_name);
 
   if (listener == nullptr) {
@@ -94,7 +95,7 @@ NativeValue* WebFPage::invokeModuleEvent(const NativeString* native_module_name,
   return return_value;
 }
 
-void WebFPage::evaluateScript(const NativeString* script, const char* url, int startLine) {
+void WebFPage::evaluateScript(const SharedNativeString* script, const char* url, int startLine) {
   if (!context_->IsContextValid())
     return;
 

--- a/bridge/core/page.cc
+++ b/bridge/core/page.cc
@@ -5,7 +5,6 @@
 #include <atomic>
 #include <unordered_map>
 
-#include "foundation/native_value_converter.h"
 #include "bindings/qjs/atomic_string.h"
 #include "bindings/qjs/binding_initializer.h"
 #include "core/dart_methods.h"
@@ -15,6 +14,7 @@
 #include "core/html/parser/html_parser.h"
 #include "event_factory.h"
 #include "foundation/logging.h"
+#include "foundation/native_value_converter.h"
 #include "page.h"
 #include "polyfill.h"
 

--- a/bridge/core/page.h
+++ b/bridge/core/page.h
@@ -39,7 +39,7 @@ class WebFPage final {
   static std::unordered_map<std::string, NativeByteCode> pluginByteCode;
 
   // evaluate JavaScript source codes in standard mode.
-  void evaluateScript(const NativeString* script, const char* url, int startLine);
+  void evaluateScript(const SharedNativeString* script, const char* url, int startLine);
   void evaluateScript(const uint16_t* script, size_t length, const char* url, int startLine);
   bool parseHTML(const char* code, size_t length);
   void evaluateScript(const char* script, size_t length, const char* url, int startLine);
@@ -50,7 +50,7 @@ class WebFPage final {
 
   [[nodiscard]] ExecutingContext* GetExecutingContext() const { return context_; }
 
-  NativeValue* invokeModuleEvent(const NativeString* moduleName,
+  NativeValue* invokeModuleEvent(SharedNativeString* moduleName,
                                  const char* eventType,
                                  void* event,
                                  NativeValue* extra);

--- a/bridge/foundation/native_string.cc
+++ b/bridge/foundation/native_string.cc
@@ -7,18 +7,24 @@
 
 namespace webf {
 
-NativeString::NativeString(const uint16_t* string, uint32_t length) : length_(length) {
-  string_ = static_cast<const uint16_t*>(malloc(length * sizeof(uint16_t)));
-  memcpy((void*)string_, string, length * sizeof(uint16_t));
+SharedNativeString::SharedNativeString(const uint16_t* string, uint32_t length) : length_(length), string_(string) {}
+
+std::unique_ptr<SharedNativeString> SharedNativeString::FromTemporaryString(const uint16_t *string, uint32_t length) {
+  const auto* new_str = static_cast<const uint16_t*>(malloc(length * sizeof(uint16_t)));
+  memcpy((void*)new_str, string, length * sizeof(uint16_t));
+  return std::make_unique<SharedNativeString>(new_str, length);
 }
 
-NativeString::NativeString(const NativeString* source) : length_(source->length()) {
-  string_ = static_cast<const uint16_t*>(malloc(source->length() * sizeof(uint16_t)));
-  memcpy((void*)string_, source->string_, source->length() * sizeof(u_int16_t));
+AutoFreeNativeString::AutoFreeNativeString(const uint16_t *string, uint32_t length): SharedNativeString(string, length) {}
+
+AutoFreeNativeString::AutoFreeNativeString(void *raw): SharedNativeString() {
+  auto* p = static_cast<AutoFreeNativeString*>(raw);
+  length_ = p->length();
+  string_ = p->string_;
 }
 
-NativeString::~NativeString() {
-  delete[] string_;
+AutoFreeNativeString::~AutoFreeNativeString() {
+  free();
 }
 
 }  // namespace webf

--- a/bridge/foundation/native_string.cc
+++ b/bridge/foundation/native_string.cc
@@ -9,15 +9,16 @@ namespace webf {
 
 SharedNativeString::SharedNativeString(const uint16_t* string, uint32_t length) : length_(length), string_(string) {}
 
-std::unique_ptr<SharedNativeString> SharedNativeString::FromTemporaryString(const uint16_t *string, uint32_t length) {
+std::unique_ptr<SharedNativeString> SharedNativeString::FromTemporaryString(const uint16_t* string, uint32_t length) {
   const auto* new_str = static_cast<const uint16_t*>(malloc(length * sizeof(uint16_t)));
   memcpy((void*)new_str, string, length * sizeof(uint16_t));
   return std::make_unique<SharedNativeString>(new_str, length);
 }
 
-AutoFreeNativeString::AutoFreeNativeString(const uint16_t *string, uint32_t length): SharedNativeString(string, length) {}
+AutoFreeNativeString::AutoFreeNativeString(const uint16_t* string, uint32_t length)
+    : SharedNativeString(string, length) {}
 
-AutoFreeNativeString::AutoFreeNativeString(void *raw): SharedNativeString() {
+AutoFreeNativeString::AutoFreeNativeString(void* raw) : SharedNativeString() {
   auto* p = static_cast<AutoFreeNativeString*>(raw);
   length_ = p->length();
   string_ = p->string_;

--- a/bridge/foundation/native_string.h
+++ b/bridge/foundation/native_string.h
@@ -5,11 +5,11 @@
 #ifndef BRIDGE_NATIVE_STRING_H
 #define BRIDGE_NATIVE_STRING_H
 
-#include <memory>
+#include <quickjs/quickjs.h>
 #include <cinttypes>
 #include <cstdlib>
 #include <cstring>
-#include <quickjs/quickjs.h>
+#include <memory>
 
 #include "foundation/macros.h"
 
@@ -24,9 +24,8 @@ struct SharedNativeString {
   inline const uint16_t* string() const { return string_; }
   inline uint32_t length() const { return length_; }
 
-  void free() const {
-    delete[] string_;
-  }
+  void free() const { delete[] string_; }
+
  protected:
   SharedNativeString() = default;
   const uint16_t* string_;

--- a/bridge/foundation/native_string.h
+++ b/bridge/foundation/native_string.h
@@ -5,25 +5,41 @@
 #ifndef BRIDGE_NATIVE_STRING_H
 #define BRIDGE_NATIVE_STRING_H
 
+#include <memory>
 #include <cinttypes>
 #include <cstdlib>
 #include <cstring>
+#include <quickjs/quickjs.h>
 
 #include "foundation/macros.h"
 
 namespace webf {
 
-struct NativeString {
-  NativeString(const uint16_t* string, uint32_t length);
-  NativeString(const NativeString* source);
-  ~NativeString();
+// SharedNativeString is a container class that accepts allocated UTF-16 strings,
+// and users are responsible for freeing their strings
+struct SharedNativeString {
+  SharedNativeString(const uint16_t* string, uint32_t length);
+  static std::unique_ptr<SharedNativeString> FromTemporaryString(const uint16_t* string, uint32_t length);
 
   inline const uint16_t* string() const { return string_; }
   inline uint32_t length() const { return length_; }
 
- private:
+  void free() const {
+    delete[] string_;
+  }
+ protected:
+  SharedNativeString() = default;
   const uint16_t* string_;
   uint32_t length_;
+};
+
+// NativeString is a container class that accepts allocated on Heap UTF-16 strings,
+// and freeing strings by itself.
+struct AutoFreeNativeString : public SharedNativeString {
+ public:
+  AutoFreeNativeString(const uint16_t* string, uint32_t length);
+  AutoFreeNativeString(void* raw);
+  ~AutoFreeNativeString();
 };
 
 }  // namespace webf

--- a/bridge/foundation/native_value.cc
+++ b/bridge/foundation/native_value.cc
@@ -13,7 +13,7 @@ NativeValue Native_NewNull() {
   return (NativeValue){.u = {.int64 = 0}, .uint32 = 0, .tag = NativeTag::TAG_NULL};
 }
 
-NativeValue Native_NewString(NativeString* string) {
+NativeValue Native_NewString(SharedNativeString* string) {
   return (NativeValue){
       .u = {.ptr = static_cast<void*>(string)},
       .uint32 = 0,
@@ -22,7 +22,7 @@ NativeValue Native_NewString(NativeString* string) {
 }
 
 NativeValue Native_NewCString(const std::string& string) {
-  std::unique_ptr<NativeString> nativeString = stringToNativeString(string);
+  std::unique_ptr<SharedNativeString> nativeString = stringToNativeString(string);
   // NativeString owned by NativeValue will be freed by users.
   return Native_NewString(nativeString.release());
 }

--- a/bridge/foundation/native_value.h
+++ b/bridge/foundation/native_value.h
@@ -67,7 +67,7 @@ struct NativeFunctionContext {
 };
 
 NativeValue Native_NewNull();
-NativeValue Native_NewString(NativeString* string);
+NativeValue Native_NewString(SharedNativeString* string);
 NativeValue Native_NewCString(const std::string& string);
 NativeValue Native_NewFloat64(double value);
 NativeValue Native_NewBool(bool value);

--- a/bridge/foundation/native_value_converter.h
+++ b/bridge/foundation/native_value_converter.h
@@ -38,12 +38,12 @@ struct NativeValueConverter<NativeTypeString> : public NativeValueConverterBase<
   }
   static NativeValue ToNativeValue(const std::string& value) { return Native_NewCString(value); }
 
-  static ImplType FromNativeValue(JSContext* ctx, NativeValue value) {
+  static ImplType FromNativeValue(JSContext* ctx, NativeValue&& value) {
     if (value.tag == NativeTag::TAG_NULL) {
       return AtomicString::Empty();
     }
     assert(value.tag == NativeTag::TAG_STRING);
-    return AtomicString(ctx, static_cast<NativeString*>(value.u.ptr));
+    return {ctx, std::make_unique<AutoFreeNativeString>(value.u.ptr)};
   }
 };
 
@@ -184,7 +184,8 @@ struct NativeValueConverter<NativeTypeArray<T>> : public NativeValueConverterBas
     std::vector<typename T::ImplType> vec;
     vec.reserve(length);
     for (int i = 0; i < length; i++) {
-      vec.emplace_back(NativeValueConverter<T>::FromNativeValue(ctx, arr[i]));
+      NativeValue v = arr[i];
+      vec.emplace_back(NativeValueConverter<T>::FromNativeValue(ctx, std::move(v)));
     }
     return vec;
   }

--- a/bridge/foundation/string_view.cc
+++ b/bridge/foundation/string_view.cc
@@ -8,7 +8,7 @@ namespace webf {
 
 StringView::StringView(const std::string& string) : bytes_(string.data()), length_(string.length()), is_8bit_(true) {}
 
-StringView::StringView(const NativeString* string)
+StringView::StringView(const SharedNativeString* string)
     : bytes_(string->string()), length_(string->length()), is_8bit_(false) {}
 
 StringView::StringView(void* bytes, unsigned length, bool is_wide_char)

--- a/bridge/foundation/string_view.h
+++ b/bridge/foundation/string_view.h
@@ -16,7 +16,7 @@ class StringView final {
   StringView() = delete;
 
   explicit StringView(const std::string& string);
-  explicit StringView(const NativeString* string);
+  explicit StringView(const SharedNativeString* string);
   explicit StringView(void* bytes, unsigned length, bool is_wide_char);
 
   bool Is8Bit() const { return is_8bit_; }

--- a/bridge/foundation/ui_command_buffer.cc
+++ b/bridge/foundation/ui_command_buffer.cc
@@ -27,7 +27,10 @@ void UICommandBuffer::addCommand(int32_t id, UICommand type, void* nativePtr) {
   addCommand(item);
 }
 
-void UICommandBuffer::addCommand(int32_t id, UICommand type, std::unique_ptr<SharedNativeString>&& args_01, void* nativePtr) {
+void UICommandBuffer::addCommand(int32_t id,
+                                 UICommand type,
+                                 std::unique_ptr<SharedNativeString>&& args_01,
+                                 void* nativePtr) {
   assert(args_01 != nullptr);
   UICommandItem item{id, static_cast<int32_t>(type), args_01.release(), nativePtr};
   addCommand(item);

--- a/bridge/foundation/ui_command_buffer.cc
+++ b/bridge/foundation/ui_command_buffer.cc
@@ -27,7 +27,7 @@ void UICommandBuffer::addCommand(int32_t id, UICommand type, void* nativePtr) {
   addCommand(item);
 }
 
-void UICommandBuffer::addCommand(int32_t id, UICommand type, std::unique_ptr<NativeString>&& args_01, void* nativePtr) {
+void UICommandBuffer::addCommand(int32_t id, UICommand type, std::unique_ptr<SharedNativeString>&& args_01, void* nativePtr) {
   assert(args_01 != nullptr);
   UICommandItem item{id, static_cast<int32_t>(type), args_01.release(), nativePtr};
   addCommand(item);
@@ -35,8 +35,8 @@ void UICommandBuffer::addCommand(int32_t id, UICommand type, std::unique_ptr<Nat
 
 void UICommandBuffer::addCommand(int32_t id,
                                  UICommand type,
-                                 std::unique_ptr<NativeString>&& args_01,
-                                 std::unique_ptr<NativeString>&& args_02,
+                                 std::unique_ptr<SharedNativeString>&& args_01,
+                                 std::unique_ptr<SharedNativeString>&& args_02,
                                  void* nativePtr) {
   assert(args_01 != nullptr);
   assert(args_02 != nullptr);

--- a/bridge/foundation/ui_command_buffer.h
+++ b/bridge/foundation/ui_command_buffer.h
@@ -38,17 +38,17 @@ enum class UICommand {
 
 struct UICommandItem {
   UICommandItem() = default;
-  UICommandItem(int32_t id, int32_t type, NativeString* args_01, NativeString* args_02, void* nativePtr)
+  UICommandItem(int32_t id, int32_t type, SharedNativeString* args_01, SharedNativeString* args_02, void* nativePtr)
       : type(type),
-        string_01(reinterpret_cast<int64_t>((new NativeString(args_01))->string())),
+        string_01(reinterpret_cast<int64_t>(args_01->string())),
         args_01_length(args_01->length()),
-        string_02(reinterpret_cast<int64_t>((new NativeString(args_02))->string())),
+        string_02(reinterpret_cast<int64_t>(args_02->string())),
         args_02_length(args_02->length()),
         id(id),
         nativePtr(reinterpret_cast<int64_t>(nativePtr)){};
-  UICommandItem(int32_t id, int32_t type, NativeString* args_01, void* nativePtr)
+  UICommandItem(int32_t id, int32_t type, SharedNativeString* args_01, void* nativePtr)
       : type(type),
-        string_01(reinterpret_cast<int64_t>((new NativeString(args_01))->string())),
+        string_01(reinterpret_cast<int64_t>(args_01->string())),
         args_01_length(args_01->length()),
         id(id),
         nativePtr(reinterpret_cast<int64_t>(nativePtr)){};
@@ -73,10 +73,10 @@ class UICommandBuffer {
   void addCommand(int32_t id, UICommand type, void* nativePtr);
   void addCommand(int32_t id,
                   UICommand type,
-                  std::unique_ptr<NativeString>&& args_01,
-                  std::unique_ptr<NativeString>&& args_02,
+                  std::unique_ptr<SharedNativeString>&& args_01,
+                  std::unique_ptr<SharedNativeString>&& args_02,
                   void* nativePtr);
-  void addCommand(int32_t id, UICommand type, std::unique_ptr<NativeString>&& args_01, void* nativePtr);
+  void addCommand(int32_t id, UICommand type, std::unique_ptr<SharedNativeString>&& args_01, void* nativePtr);
   UICommandItem* data();
   int64_t size();
   bool empty();

--- a/bridge/scripts/code_generator/src/idl/generateSource.ts
+++ b/bridge/scripts/code_generator/src/idl/generateSource.ts
@@ -111,7 +111,7 @@ export function generateRawTypeValue(type: ParameterType, is32Bit: boolean = fal
         return 'int64_t';
       }
 
-      return 'NativeString*';
+      return 'SharedNativeString*';
     }
     default:
       if (is32Bit) {

--- a/bridge/scripts/code_generator/templates/idl_templates/interface.cc.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/interface.cc.tpl
@@ -167,11 +167,10 @@ static JSValue <%= prop.name %>AttributeGetCallback(JSContext* ctx, JSValueConst
 
   <% if (prop.typeMode && prop.typeMode.dartImpl) { %>
   ExceptionState exception_state;
-  auto&& native_value = <%= blob.filename %>->GetBindingProperty(binding_call_methods::k<%= prop.name %>, exception_state);
   <% if (isTypeNeedAllocate(prop.type)) { %>
-  typename <%= generateNativeValueTypeConverter(prop.type) %>::ImplType v = NativeValueConverter<<%= generateNativeValueTypeConverter(prop.type) %>>::FromNativeValue(ctx, native_value);
+  typename <%= generateNativeValueTypeConverter(prop.type) %>::ImplType v = NativeValueConverter<<%= generateNativeValueTypeConverter(prop.type) %>>::FromNativeValue(ctx, <%= blob.filename %>->GetBindingProperty(binding_call_methods::k<%= prop.name %>, exception_state));
   <% } else { %>
-  typename <%= generateNativeValueTypeConverter(prop.type) %>::ImplType v = NativeValueConverter<<%= generateNativeValueTypeConverter(prop.type) %>>::FromNativeValue(native_value);
+  typename <%= generateNativeValueTypeConverter(prop.type) %>::ImplType v = NativeValueConverter<<%= generateNativeValueTypeConverter(prop.type) %>>::FromNativeValue(<%= blob.filename %>->GetBindingProperty(binding_call_methods::k<%= prop.name %>, exception_state));
   <% } %>
   if (UNLIKELY(exception_state.HasException())) {
     return exception_state.ToQuickJS();

--- a/bridge/test/webf_test_context.cc
+++ b/bridge/test/webf_test_context.cc
@@ -229,9 +229,9 @@ static JSValue simulateInputText(JSContext* ctx, JSValueConst this_val, int argc
     return JS_ThrowTypeError(ctx, "Failed to execute '__webf_simulate_keypress__': first arguments should be a string");
   }
 
-  std::unique_ptr<NativeString> nativeString = webf::jsValueToNativeString(ctx, charStringValue);
+  std::unique_ptr<SharedNativeString> nativeString = webf::jsValueToNativeString(ctx, charStringValue);
   void* p = static_cast<void*>(nativeString.get());
-  context->dartMethodPtr()->simulateInputText(static_cast<NativeString*>(p));
+  context->dartMethodPtr()->simulateInputText(static_cast<SharedNativeString*>(p));
   return JS_NULL;
 };
 
@@ -290,7 +290,7 @@ void WebFTestContext::invokeExecuteTest(ExecuteCallback executeCallback) {
 
     WEBF_LOG(VERBOSE) << "Done..";
 
-    std::unique_ptr<NativeString> status = webf::jsValueToNativeString(ctx, statusValue);
+    std::unique_ptr<SharedNativeString> status = webf::jsValueToNativeString(ctx, statusValue);
     callbackContext->executeCallback(callbackContext->context->contextId(), status.get());
     JS_FreeValue(ctx, proxyObject);
     callbackContext->webf_context->execute_test_proxy_object_ = JS_NULL;

--- a/bridge/test/webf_test_env.cc
+++ b/bridge/test/webf_test_env.cc
@@ -68,9 +68,9 @@ static void unlink_callback(JSThreadState* ts, JSFrameCallback* th) {
 
 NativeValue* TEST_invokeModule(void* callbackContext,
                                int32_t contextId,
-                               NativeString* moduleName,
-                               NativeString* method,
-                               NativeString* params,
+                               SharedNativeString* moduleName,
+                               SharedNativeString* method,
+                               SharedNativeString* params,
                                AsyncModuleCallback callback) {
   std::string module = nativeStringToStdString(moduleName);
 
@@ -170,7 +170,7 @@ double TEST_devicePixelRatio(int32_t contextId) {
   return 1.0;
 }
 
-NativeString* TEST_platformBrightness(int32_t contextId) {
+SharedNativeString* TEST_platformBrightness(int32_t contextId) {
   return nullptr;
 }
 
@@ -296,7 +296,7 @@ void TEST_onMatchImageSnapshot(void* callbackContext,
                                int32_t contextId,
                                uint8_t* bytes,
                                int32_t length,
-                               NativeString* name,
+                               SharedNativeString* name,
                                MatchImageSnapshotCallback callback) {
   callback(callbackContext, contextId, 1, nullptr);
 }
@@ -307,7 +307,7 @@ const char* TEST_environment() {
 
 void TEST_simulatePointer(MousePointer*, int32_t length, int32_t pointer) {}
 
-void TEST_simulateInputText(NativeString* nativeString) {}
+void TEST_simulateInputText(SharedNativeString* nativeString) {}
 
 std::vector<uint64_t> TEST_getMockDartMethods(OnJSError onJSError) {
   std::vector<uint64_t> mockMethods{reinterpret_cast<uint64_t>(TEST_invokeModule),

--- a/bridge/webf_bridge.cc
+++ b/bridge/webf_bridge.cc
@@ -77,7 +77,7 @@ void disposePage(void* page_) {
 void evaluateScripts(void* page_, NativeString* code, const char* bundleFilename, int32_t startLine) {
   auto page = reinterpret_cast<webf::WebFPage*>(page_);
   assert(std::this_thread::get_id() == page->currentThread());
-  page->evaluateScript(reinterpret_cast<webf::NativeString*>(code), bundleFilename, startLine);
+  page->evaluateScript(reinterpret_cast<webf::SharedNativeString*>(code), bundleFilename, startLine);
 }
 
 void evaluateQuickjsByteCode(void* page_, uint8_t* bytes, int32_t byteLen) {
@@ -99,7 +99,7 @@ NativeValue* invokeModuleEvent(void* page_,
                                NativeValue* extra) {
   auto page = reinterpret_cast<webf::WebFPage*>(page_);
   assert(std::this_thread::get_id() == page->currentThread());
-  auto* result = page->invokeModuleEvent(reinterpret_cast<webf::NativeString*>(module_name), eventType, event,
+  auto* result = page->invokeModuleEvent(reinterpret_cast<webf::SharedNativeString*>(module_name), eventType, event,
                                          reinterpret_cast<webf::NativeValue*>(extra));
   return reinterpret_cast<NativeValue*>(result);
 }

--- a/bridge/webf_bridge_test.cc
+++ b/bridge/webf_bridge_test.cc
@@ -18,8 +18,8 @@ void* initTestFramework(void* page_) {
 
 int8_t evaluateTestScripts(void* testContext, void* code, const char* bundleFilename, int startLine) {
   return reinterpret_cast<webf::WebFTestContext*>(testContext)
-      ->evaluateTestScripts(static_cast<webf::NativeString*>(code)->string(),
-                            static_cast<webf::NativeString*>(code)->length(), bundleFilename, startLine);
+      ->evaluateTestScripts(static_cast<webf::SharedNativeString*>(code)->string(),
+                            static_cast<webf::SharedNativeString*>(code)->length(), bundleFilename, startLine);
 }
 
 void executeTest(void* testContext, ExecuteCallback executeCallback) {


### PR DESCRIPTION
This patch can fix the memory leaks when send and receive string kind values with Dart.

The Fixed results:

<img width="841" alt="image" src="https://user-images.githubusercontent.com/4409743/226603614-a21bf6c1-ad26-4f38-b20a-a943a9344efb.png">

Before:

<img width="475" alt="image" src="https://user-images.githubusercontent.com/4409743/226604589-43efc3b5-15d0-4818-ad73-219ee2b48e8c.png">

