### PR TITLE
fix: binding object should be returned with new instance.

### DIFF
--- a/integration_tests/specs/dom/nodes/element.ts
+++ b/integration_tests/specs/dom/nodes/element.ts
@@ -76,6 +76,12 @@ describe('DOM Element API', () => {
 
   });
 
+  it('should works when getting multiple zero rects', () => {
+    const div = document.createElement('div');
+    expect(JSON.parse(JSON.stringify(div.getBoundingClientRect()))).toEqual({bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0, x: 0, y: 0});
+    expect(JSON.parse(JSON.stringify(div.getBoundingClientRect()))).toEqual({bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0, x: 0, y: 0});
+  });
+
   it('children should only contain elements', () => {
     let container = document.createElement('div');
     let a = document.createElement('div');

--- a/webf/lib/src/dom/bounding_client_rect.dart
+++ b/webf/lib/src/dom/bounding_client_rect.dart
@@ -8,7 +8,7 @@ import 'package:webf/bridge.dart';
 import 'package:webf/foundation.dart';
 
 class BoundingClientRect extends BindingObject {
-  static BoundingClientRect zero = BoundingClientRect(x: 0, y: 0, width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0);
+  static BoundingClientRect get zero => BoundingClientRect(x: 0, y: 0, width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0);
 
   final double x;
   final double y;


### PR DESCRIPTION
BindingObjects are shared between C++ and Dart and will be freed by the QuickJS garbage collector in the end. We should return a new instance from Dart to C++ every time.