### PR TITLE
fix: CanvasRenderingContext2D should keep alive with Canvas Element.

### DIFF
--- a/bridge/core/html/canvas/html_canvas_element.cc
+++ b/bridge/core/html/canvas/html_canvas_element.cc
@@ -21,7 +21,8 @@ CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, 
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
 
   if (type == canvas_types::k2d) {
-    CanvasRenderingContext* context = MakeGarbageCollected<CanvasRenderingContext2D>(GetExecutingContext(), native_binding_object);
+    CanvasRenderingContext* context =
+        MakeGarbageCollected<CanvasRenderingContext2D>(GetExecutingContext(), native_binding_object);
     running_context_2ds_.emplace_back(context);
     return context;
   }
@@ -30,7 +31,7 @@ CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, 
 }
 
 void HTMLCanvasElement::Trace(GCVisitor* visitor) const {
-  for(auto&& context : running_context_2ds_) {
+  for (auto&& context : running_context_2ds_) {
     visitor->Trace(context);
   }
 }

--- a/bridge/core/html/canvas/html_canvas_element.cc
+++ b/bridge/core/html/canvas/html_canvas_element.cc
@@ -14,17 +14,25 @@ namespace webf {
 
 HTMLCanvasElement::HTMLCanvasElement(Document& document) : HTMLElement(html_names::kcanvas, &document) {}
 
-CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, ExceptionState& exception_state) const {
+CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, ExceptionState& exception_state) {
   NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), type)};
   NativeValue value = InvokeBindingMethod(binding_call_methods::kgetContext, 1, arguments, exception_state);
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
 
   if (type == canvas_types::k2d) {
-    return MakeGarbageCollected<CanvasRenderingContext2D>(GetExecutingContext(), native_binding_object);
+    CanvasRenderingContext* context = MakeGarbageCollected<CanvasRenderingContext2D>(GetExecutingContext(), native_binding_object);
+    running_context_2ds_.emplace_back(context);
+    return context;
   }
 
   return nullptr;
+}
+
+void HTMLCanvasElement::Trace(GCVisitor* visitor) const {
+  for(auto&& context : running_context_2ds_) {
+    visitor->Trace(context);
+  }
 }
 
 bool HTMLCanvasElement::IsAttributeDefinedInternal(const AtomicString& key) const {

--- a/bridge/core/html/canvas/html_canvas_element.h
+++ b/bridge/core/html/canvas/html_canvas_element.h
@@ -5,6 +5,7 @@
 #ifndef BRIDGE_CORE_HTML_CANVAS_HTML_CANVAS_ELEMENT_H_
 #define BRIDGE_CORE_HTML_CANVAS_HTML_CANVAS_ELEMENT_H_
 
+#include <vector>
 #include "canvas_rendering_context.h"
 #include "core/html/html_element.h"
 
@@ -16,9 +17,13 @@ class HTMLCanvasElement : public HTMLElement {
  public:
   explicit HTMLCanvasElement(Document&);
 
-  CanvasRenderingContext* getContext(const AtomicString& type, ExceptionState& exception_state) const;
+  CanvasRenderingContext* getContext(const AtomicString& type, ExceptionState& exception_state);
 
   bool IsAttributeDefinedInternal(const AtomicString& key) const override;
+
+  void Trace(GCVisitor* visitor) const override;
+
+  std::vector<Member<CanvasRenderingContext>> running_context_2ds_;
 };
 
 }  // namespace webf


### PR DESCRIPTION
If the canvasElement are still attached to the DOM tree, we should keep the CanvasRenderingContext alive until this element are disposed by GC.