### PR TITLE
feat: invalidate cache when expect errors

### DIFF
--- a/webf/lib/src/bridge/to_native.dart
+++ b/webf/lib/src/bridge/to_native.dart
@@ -144,7 +144,13 @@ Future<bool> evaluateScripts(int contextId, String code, {String? url, int line 
 
   QuickJSByteCodeCacheObject cacheObject = await QuickJSByteCodeCache.getCacheObject(code);
   if (QuickJSByteCodeCacheObject.cacheMode == ByteCodeCacheMode.DEFAULT && cacheObject.valid && cacheObject.bytes != null) {
-    return evaluateQuickjsByteCode(contextId, cacheObject.bytes!);
+    bool result = evaluateQuickjsByteCode(contextId, cacheObject.bytes!);
+    // If the bytecode evaluate failed, remove the cached file and fallback to raw javascript mode.
+    if (!result) {
+      await cacheObject.remove();
+    }
+
+    return result;
   } else {
     Pointer<NativeString> nativeString = stringToNativeString(code);
     Pointer<Utf8> _url = url.toNativeUtf8();

--- a/webf/lib/src/foundation/bundle.dart
+++ b/webf/lib/src/foundation/bundle.dart
@@ -37,6 +37,18 @@ bool _isSupportedBytecode(String mimeType, Uri? uri) {
   return false;
 }
 
+bool isGzip(List<int> data) {
+  if (data.length < 2) {
+    return false;
+  }
+
+  int magicNumber1 = data[0];
+  int magicNumber2 = data[1];
+
+  return magicNumber1 == 0x1F && magicNumber2 == 0x8B;
+}
+
+
 // The default accept request header.
 // The order is HTML -> KBC -> JavaScript.
 String _acceptHeader() {
@@ -173,12 +185,8 @@ class DataBundle extends WebFBundle {
 // The bundle that source from http or https.
 class NetworkBundle extends WebFBundle {
   // Do not access this field directly; use [_httpClient] instead.
-  // We set `autoUncompress` to false to ensure that we can trust the value of
-  // the `Content-CSSLength` HTTP header. We automatically uncompress the content
-  // in our call to [consolidateHttpClientResponseBytes].
   static final HttpClient _sharedHttpClient = HttpClient()
-    ..userAgent = NavigatorModule.getUserAgent()
-    ..autoUncompress = false;
+    ..userAgent = NavigatorModule.getUserAgent();
 
   NetworkBundle(String url, {this.additionalHttpHeaders}) : super(url);
 
@@ -202,7 +210,13 @@ class NetworkBundle extends WebFBundle {
         ErrorSummary('Unable to load asset: $url'),
         IntProperty('HTTP status code', response.statusCode),
       ]);
-    final Uint8List bytes = await consolidateHttpClientResponseBytes(response);
+    Uint8List bytes = await consolidateHttpClientResponseBytes(response);
+
+    // To maintain compatibility with older versions of WebF, which save Gzip content in caches, we should check the bytes
+    // and decode them if they are in gzip format.
+    if (isGzip(bytes)) {
+      bytes = Uint8List.fromList(gzip.decoder.convert(bytes));
+    }
 
     if (bytes.isEmpty) {
       await invalidateCache();

--- a/webf/lib/src/html/script.dart
+++ b/webf/lib/src/html/script.dart
@@ -41,9 +41,15 @@ class ScriptRunner {
     // Evaluate bundle.
     if (bundle.isJavascript) {
       final String contentInString = await resolveStringFromData(bundle.data!, preferSync: !async);
-      await evaluateScripts(contextId, contentInString, url: bundle.url);
+      bool result = await evaluateScripts(contextId, contentInString, url: bundle.url);
+      if (!result) {
+        throw FlutterError('Script code are not valid to evaluate.');
+      }
     } else if (bundle.isBytecode) {
-      evaluateQuickjsByteCode(contextId, bundle.data!);
+      bool result = evaluateQuickjsByteCode(contextId, bundle.data!);
+      if (!result) {
+        throw FlutterError('Bytecode are not valid to execute.');
+      }
     } else {
       throw FlutterError('Unknown type for <script> to execute. $url');
     }
@@ -86,6 +92,7 @@ class ScriptRunner {
       } catch (err, stack) {
         debugPrint('$err\n$stack');
         _document.decrementDOMContentLoadedEventDelayCount();
+        await bundle.invalidateCache();
         return;
       } finally {
         bundle.dispose();

--- a/webf/lib/src/painting/cached_network_image.dart
+++ b/webf/lib/src/painting/cached_network_image.dart
@@ -109,7 +109,11 @@ class CachedNetworkImage extends ImageProvider<CachedNetworkImageKey> {
         },
       );
 
-      if (bytes.lengthInBytes == 0) throw Exception('Image from network is an empty file: $resolved');
+      if (bytes.lengthInBytes == 0) {
+        HttpCacheObject cacheObject = await cacheController.getCacheObject(resolved);
+        await cacheObject.remove();
+        throw Exception('Image from network is an empty file: $resolved');
+      }
 
       return bytes;
     } finally {


### PR DESCRIPTION
When loading web pages, the page will downloads scripts and stylesheets. We have two different types of caches to optimize page load times. One is the HttpCache, which caches the HTTP response results and may replace the actual http requests if they are valid to use. The second one is the bytecode cache, which caches the quickjs bytecode results from raw javascript source codes to reduce the parsing time of the quickjs engine. 

All these cache files are stored on client's disk. If these cache files become corrupted, they can break the page, even if the files on the remote server are correct. 

To avoid potential load errors, we have implemented fallback operations that invalidate caches if the quickjs report errors during the initial stage.

Additionnal features:  decompress gzip content to caches to avoid decompression at load times.