### PR TITLE
fix: fix http cache control parse.

### DIFF
--- a/webf/test/fixtures/GET_js_over_128k
+++ b/webf/test/fixtures/GET_js_over_128k
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 Date: Tue, 24 Aug 2021 03:45:23 GMT
-Cache-Control: max-age=900
+Cache-Control: public, max-age=900
 Content-Type: application/javascript
 Content-Length: 488796
 ETag: "02E1E2621F0192E3559631E94E2D2D6A"


### PR DESCRIPTION
Fix the issue where the HTTP response wasn't cached when the `cache-control` header was set to `public, max-age=[value]` instead of just `max-age=[value]`