### PR TITLE
fix: fix crash when cancelAnimationFrame in frame callbacks.

### DIFF
--- a/bridge/core/dom/document.h
+++ b/bridge/core/dom/document.h
@@ -95,6 +95,7 @@ class Document : public ContainerNode, public TreeScope {
 
   uint32_t RequestAnimationFrame(const std::shared_ptr<FrameCallback>& callback, ExceptionState& exception_state);
   void CancelAnimationFrame(uint32_t request_id, ExceptionState& exception_state);
+  ScriptAnimationController* script_animations() { return &script_animation_controller_; };
 
   // Helper functions for forwarding LocalDOMWindow event related tasks to the
   // LocalDOMWindow if it exists.

--- a/bridge/core/dom/frame_request_callback_collection.cc
+++ b/bridge/core/dom/frame_request_callback_collection.cc
@@ -39,17 +39,24 @@ void FrameCallback::Trace(GCVisitor* visitor) const {
 
 void FrameRequestCallbackCollection::RegisterFrameCallback(uint32_t callback_id,
                                                            const std::shared_ptr<FrameCallback>& frame_callback) {
-  frameCallbacks_[callback_id] = frame_callback;
+  assert(frame_callbacks_.count(callback_id) == 0);
+  frame_callbacks_[callback_id] = frame_callback;
 }
 
-void FrameRequestCallbackCollection::CancelFrameCallback(uint32_t callbackId) {
-  if (frameCallbacks_.count(callbackId) == 0)
+void FrameRequestCallbackCollection::RemoveFrameCallback(uint32_t callback_id) {
+  if (frame_callbacks_.count(callback_id) == 0)
     return;
-  frameCallbacks_.erase(callbackId);
+  frame_callbacks_.erase(callback_id);
+}
+
+std::shared_ptr<FrameCallback> FrameRequestCallbackCollection::GetFrameCallback(uint32_t callback_id) {
+  if (frame_callbacks_.count(callback_id) == 0)
+    return nullptr;
+  return frame_callbacks_[callback_id];
 }
 
 void FrameRequestCallbackCollection::Trace(GCVisitor* visitor) const {
-  for (auto& entry : frameCallbacks_) {
+  for (auto& entry : frame_callbacks_) {
     entry.second->Trace(visitor);
   }
 }

--- a/bridge/core/dom/frame_request_callback_collection.h
+++ b/bridge/core/dom/frame_request_callback_collection.h
@@ -25,14 +25,10 @@ class FrameCallback {
   ExecutingContext* context() { return context_; };
 
   FrameStatus status() { return status_; }
-  void SetStatus(FrameStatus status) {
-    status_ = status;
-  }
+  void SetStatus(FrameStatus status) { status_ = status; }
 
   uint32_t frameId() { return frame_id_; }
-  void SetFrameId(uint32_t id) {
-    frame_id_ = id;
-  }
+  void SetFrameId(uint32_t id) { frame_id_ = id; }
 
   void Trace(GCVisitor* visitor) const;
 

--- a/bridge/core/dom/frame_request_callback_collection.h
+++ b/bridge/core/dom/frame_request_callback_collection.h
@@ -9,10 +9,13 @@
 
 namespace webf {
 
+class FrameRequestCallbackCollection;
+
 // |FrameCallback| is an interface type which generalizes callbacks which are
 // invoked when a script-based animation needs to be resampled.
 class FrameCallback {
  public:
+  enum FrameStatus { kPending, kExecuting, kFinished, kCanceled };
   static std::shared_ptr<FrameCallback> Create(ExecutingContext* context, const std::shared_ptr<QJSFunction>& callback);
 
   FrameCallback(ExecutingContext* context, std::shared_ptr<QJSFunction> callback);
@@ -21,22 +24,35 @@ class FrameCallback {
 
   ExecutingContext* context() { return context_; };
 
+  FrameStatus status() { return status_; }
+  void SetStatus(FrameStatus status) {
+    status_ = status;
+  }
+
+  uint32_t frameId() { return frame_id_; }
+  void SetFrameId(uint32_t id) {
+    frame_id_ = id;
+  }
+
   void Trace(GCVisitor* visitor) const;
 
  private:
   std::shared_ptr<QJSFunction> callback_;
+  FrameStatus status_;
+  uint32_t frame_id_;
   ExecutingContext* context_{nullptr};
 };
 
 class FrameRequestCallbackCollection final {
  public:
   void RegisterFrameCallback(uint32_t callback_id, const std::shared_ptr<FrameCallback>& frame_callback);
-  void CancelFrameCallback(uint32_t callback_id);
+  void RemoveFrameCallback(uint32_t callback_id);
+  std::shared_ptr<FrameCallback> GetFrameCallback(uint32_t callback_id);
 
   void Trace(GCVisitor* visitor) const;
 
  private:
-  std::unordered_map<uint32_t, std::shared_ptr<FrameCallback>> frameCallbacks_;
+  std::unordered_map<uint32_t, std::shared_ptr<FrameCallback>> frame_callbacks_;
 };
 
 }  // namespace webf

--- a/bridge/core/dom/scripted_animation_controller.cc
+++ b/bridge/core/dom/scripted_animation_controller.cc
@@ -47,7 +47,8 @@ uint32_t ScriptAnimationController::RegisterFrameCallback(const std::shared_ptr<
 
   frame_callback->SetStatus(FrameCallback::FrameStatus::kPending);
 
-  uint32_t requestId = context->dartMethodPtr()->requestAnimationFrame(frame_callback.get(), context->contextId(),                                                   handleRAFTransientCallback);
+  uint32_t requestId = context->dartMethodPtr()->requestAnimationFrame(frame_callback.get(), context->contextId(),
+                                                                       handleRAFTransientCallback);
   frame_callback->SetFrameId(requestId);
   // Register frame callback to collection.
   frame_request_callback_collection_.RegisterFrameCallback(requestId, frame_callback);

--- a/bridge/core/dom/scripted_animation_controller.cc
+++ b/bridge/core/dom/scripted_animation_controller.cc
@@ -4,8 +4,8 @@
  */
 
 #include "scripted_animation_controller.h"
-#include "frame_request_callback_collection.h"
 #include "document.h"
+#include "frame_request_callback_collection.h"
 
 namespace webf {
 

--- a/bridge/core/dom/scripted_animation_controller.cc
+++ b/bridge/core/dom/scripted_animation_controller.cc
@@ -22,6 +22,8 @@ static void handleRAFTransientCallback(void* ptr, int32_t contextId, double high
     return;
   }
 
+  assert(frame_callback->status() == FrameCallback::FrameStatus::kPending);
+
   frame_callback->SetStatus(FrameCallback::FrameStatus::kExecuting);
 
   // Trigger callbacks.
@@ -45,9 +47,8 @@ uint32_t ScriptAnimationController::RegisterFrameCallback(const std::shared_ptr<
 
   frame_callback->SetStatus(FrameCallback::FrameStatus::kPending);
 
-  uint32_t requestId = context->dartMethodPtr()->requestAnimationFrame(frame_callback.get(), context->contextId(),
-                                                                       handleRAFTransientCallback);
-
+  uint32_t requestId = context->dartMethodPtr()->requestAnimationFrame(frame_callback.get(), context->contextId(),                                                   handleRAFTransientCallback);
+  frame_callback->SetFrameId(requestId);
   // Register frame callback to collection.
   frame_request_callback_collection_.RegisterFrameCallback(requestId, frame_callback);
 
@@ -68,11 +69,10 @@ void ScriptAnimationController::CancelFrameCallback(ExecutingContext* context,
 
   auto frame_callback = frame_request_callback_collection_.GetFrameCallback(callback_id);
   if (frame_callback != nullptr) {
-    if (frame_callback->status() == FrameCallback::FrameStatus::kExecuting) {
-      frame_callback->SetStatus(FrameCallback::kCanceled);
-    } else {
+    if (frame_callback->status() != FrameCallback::FrameStatus::kExecuting) {
       frame_request_callback_collection_.RemoveFrameCallback(callback_id);
     }
+    frame_callback->SetStatus(FrameCallback::kCanceled);
   }
 }
 

--- a/bridge/core/dom/scripted_animation_controller.h
+++ b/bridge/core/dom/scripted_animation_controller.h
@@ -15,7 +15,9 @@ class ScriptAnimationController {
  public:
   // Animation frame callbacks are used for requestAnimationFrame().
   uint32_t RegisterFrameCallback(const std::shared_ptr<FrameCallback>& callback, ExceptionState& exception_state);
-  void CancelFrameCallback(ExecutingContext* context, uint32_t callbackId, ExceptionState& exception_state);
+  void CancelFrameCallback(ExecutingContext* context, uint32_t callback_id, ExceptionState& exception_state);
+
+  FrameRequestCallbackCollection* callbackCollection() { return &frame_request_callback_collection_; };
 
   void Trace(GCVisitor* visitor) const;
 

--- a/bridge/core/frame/dom_timer_coordinator.cc
+++ b/bridge/core/frame/dom_timer_coordinator.cc
@@ -60,7 +60,12 @@ void DOMTimerCoordinator::forceStopTimeoutById(int32_t timer_id) {
     return;
   }
   auto timer = active_timers_[timer_id];
-  timer->SetStatus(DOMTimer::TimerStatus::kCanceled);
+
+  if (timer->status() == DOMTimer::TimerStatus::kExecuting) {
+    timer->SetStatus(DOMTimer::TimerStatus::kCanceled);
+  } else {
+    removeTimeoutById(timer->timerId());
+  }
 }
 
 std::shared_ptr<DOMTimer> DOMTimerCoordinator::getTimerById(int32_t timer_id) {

--- a/integration_tests/specs/window/global.ts
+++ b/integration_tests/specs/window/global.ts
@@ -54,4 +54,11 @@ describe('window', () => {
 
     await simulateClick(10, 10);
   });
+
+  it('should work when cancelAnimationFrame in frame callback', (done) => {
+    const frameId = requestAnimationFrame(() => {
+      cancelAnimationFrame(frameId);
+      done();
+    });
+  });
 });

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -310,6 +310,7 @@ class WebFViewController implements WidgetsBindingObserver, ElementsBindingObser
 
   // Dispose controller and recycle all resources.
   void dispose() {
+    _disposed = true;
     debugDOMTreeChanged = null;
 
     _teardownObserver();
@@ -324,7 +325,6 @@ class WebFViewController implements WidgetsBindingObserver, ElementsBindingObser
 
     document.dispose();
     window.dispose();
-    _disposed = true;
   }
 
   VoidCallback? _originalOnPlatformBrightnessChanged;

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -993,8 +993,8 @@ class WebFController {
   }
 
   void dispose() {
-    _view.dispose();
     _module.dispose();
+    _view.dispose();
     _controllerMap[_view.contextId] = null;
     _controllerMap.remove(_view.contextId);
     _nameIdMap.remove(name);


### PR DESCRIPTION
Fix app crashed when canceling animationFrame inside of frame callback in iOS devices.

Crash demo:

```javascript
    const div = document.createElement('div');
    div.onclick = () => {
        let t = requestAnimationFrame(() => {
            cancelAnimationFrame(t);
            document.body.appendChild(document.createTextNode('cleared'));
        });
    };
    div.textContent = 'click';
    document.body.appendChild(div);
```