### PR TITLE
feat: use lldb to run the test.

### DIFF
--- a/integration_tests/scripts/core_integration_starter.js
+++ b/integration_tests/scripts/core_integration_starter.js
@@ -25,7 +25,7 @@ function startIntegrationTest() {
     throw new Error('Unsupported platform:' + platform);
   }
 
-  const tester = spawn(testExecutable, [], {
+  const tester = spawn('lldb', [testExecutable, '-o', '\'run\'', '-o', '\'exit\''], {
     env: {
       ...process.env,
       WEBF_ENABLE_TEST: 'true',
@@ -52,6 +52,10 @@ function startIntegrationTest() {
     if (code != 0) {
       process.exit(1);
     }
+  });
+
+  process.on('beforeExit', () => {
+    tester.kill();
   });
 }
 


### PR DESCRIPTION
Run the integration test with LLDB can capture the reports when the tests crashed.