### PR TITLE
fix: fix GIF images cause rendering optimze rendering performance overhead.

### DIFF
--- a/bridge/core/frame/dom_timer_coordinator.cc
+++ b/bridge/core/frame/dom_timer_coordinator.cc
@@ -62,7 +62,8 @@ void DOMTimerCoordinator::forceStopTimeoutById(int32_t timer_id) {
 
   if (timer->status() == DOMTimer::TimerStatus::kExecuting) {
     timer->SetStatus(DOMTimer::TimerStatus::kCanceled);
-  } else {
+  } else if (timer->status() == DOMTimer::TimerStatus::kPending ||
+             (timer->kind() == DOMTimer::TimerKind::kMultiple && timer->status() == DOMTimer::TimerStatus::kFinished)) {
     removeTimeoutById(timer->timerId());
   }
 }

--- a/bridge/core/frame/window_or_worker_global_scope.cc
+++ b/bridge/core/frame/window_or_worker_global_scope.cc
@@ -50,10 +50,19 @@ static void handlePersistentCallback(void* ptr, int32_t contextId, const char* e
     return;
 
   if (timer->status() == DOMTimer::TimerStatus::kCanceled) {
+    context->Timers()->removeTimeoutById(timer->timerId());
     return;
   }
 
+  timer->SetStatus(DOMTimer::TimerStatus::kExecuting);
   handleTimerCallback(timer, errmsg);
+
+  if (timer->status() == DOMTimer::TimerStatus::kCanceled) {
+    context->Timers()->removeTimeoutById(timer->timerId());
+    return;
+  }
+
+  timer->SetStatus(DOMTimer::TimerStatus::kFinished);
 }
 
 int WindowOrWorkerGlobalScope::setTimeout(ExecutingContext* context,

--- a/integration_tests/spec_group.json
+++ b/integration_tests/spec_group.json
@@ -7,6 +7,7 @@
       "specs/cookie/**/*.{js,jsx,ts,tsx,html}",
       "specs/fetch/**/*.{js,jsx,ts,tsx,html}",
       "specs/modules/**/*.{js,jsx,ts,tsx,html}",
+      "specs/url/**/*.{js,jsx,ts,tsx,html}",
       "specs/navigator/**/*.{js,jsx,ts,tsx,html}",
       "specs/performance/**/*.{js,jsx,ts,tsx,html}",
       "specs/timer/**/*.{js,jsx,ts,tsx,html}",

--- a/integration_tests/specs/dom/elements/img.ts
+++ b/integration_tests/specs/dom/elements/img.ts
@@ -370,8 +370,11 @@ describe('Tags img', () => {
       setTimeout(async () => {
         // When img re-append to document, to Gif image will continue to play.
         document.body.appendChild(img);
-        await snapshot(img);
-        done();
+        requestAnimationFrame(async () => {
+          await snapshot(img);
+          done();
+        })
+
       }, 200);
     };
 

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -103,9 +103,9 @@ class ImageElement extends Element {
     properties['src'] = BindingObjectProperty(getter: () => src, setter: (value) => src = castToType<String>(value));
     properties['loading'] =
         BindingObjectProperty(getter: () => loading, setter: (value) => loading = castToType<String>(value));
-    properties['width'] = BindingObjectProperty(getter: () => width, setter: (value) => widthValue = castToType<String>(value));
+    properties['width'] = BindingObjectProperty(getter: () => width, setter: (value) => width = value);
     properties['height'] =
-        BindingObjectProperty(getter: () => height, setter: (value) => heightValue = castToType<String>(value));
+        BindingObjectProperty(getter: () => height, setter: (value) => height = value);
     properties['scaling'] =
         BindingObjectProperty(getter: () => scaling, setter: (value) => scaling = castToType<String>(value));
     properties['naturalWidth'] = BindingObjectProperty(getter: () => naturalWidth);
@@ -119,8 +119,18 @@ class ImageElement extends Element {
 
     attributes['src'] = ElementAttributeProperty(setter: (value) => src = attributeToProperty<String>(value));
     attributes['loading'] = ElementAttributeProperty(setter: (value) => loading = attributeToProperty<String>(value));
-    attributes['width'] = ElementAttributeProperty(setter: (value) => widthValue = attributeToProperty<String>(value));
-    attributes['height'] = ElementAttributeProperty(setter: (value) => heightValue = attributeToProperty<String>(value));
+    attributes['width'] = ElementAttributeProperty(setter: (value) {
+      CSSLengthValue input = CSSLength.parseLength(attributeToProperty<String>(value), renderStyle);
+      if (input.value != null) {
+        width = input.value!.toInt();
+      }
+    });
+    attributes['height'] = ElementAttributeProperty(setter: (value) {
+      CSSLengthValue input = CSSLength.parseLength(attributeToProperty<String>(value), renderStyle);
+      if (input.value != null) {
+        height = input.value!.toInt();
+      }
+    });
     attributes['scaling'] = ElementAttributeProperty(setter: (value) => scaling = attributeToProperty<String>(value));
   }
 
@@ -539,8 +549,9 @@ class ImageElement extends Element {
     }
   }
 
-  set widthValue(String value) {
-    internalSetAttribute(WIDTH, value);
+  set width(int value) {
+    if (value == width) return;
+    internalSetAttribute(WIDTH, '${value}px');
     if (_shouldScaling) {
       _decode(updateImageProvider: true);
     } else {
@@ -548,8 +559,9 @@ class ImageElement extends Element {
     }
   }
 
-  set heightValue(String value) {
-    internalSetAttribute(HEIGHT, value);
+  set height(int value) {
+    if (value == height) return;
+    internalSetAttribute(HEIGHT, '${value}px');
     if (_shouldScaling) {
       _decode(updateImageProvider: true);
     } else {

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -449,16 +449,8 @@ class ImageElement extends Element {
     // the image when they no longer need to access it or draw it.
     ui.Image? clonedImage = _cachedImageInfo?.image.clone();
     if (clonedImage != null) {
-      bool isSizeChanged = true;
-      if (_renderImage != null && _renderImage!.image != null) {
-        isSizeChanged = _renderImage!.image!.width != clonedImage.width ||
-            _renderImage!.image!.height != clonedImage.height;
-      }
-
       _renderImage?.image = clonedImage;
-      if (isSizeChanged) {
-        _resizeImage();
-      }
+      _resizeImage();
     }
   }
 

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -318,6 +318,10 @@ class ImageElement extends Element {
     renderStyle.intrinsicWidth = naturalWidth.toDouble();
     renderStyle.intrinsicHeight = naturalHeight.toDouble();
 
+    // Set naturalWidth and naturalHeight to renderImage to avoid relayout when size didn't changes.
+    _renderImage!.width = naturalWidth.toDouble();
+    _renderImage!.height = naturalHeight.toDouble();
+
     if (naturalWidth == 0.0 || naturalHeight == 0.0) {
       renderStyle.aspectRatio = null;
     } else {
@@ -445,8 +449,16 @@ class ImageElement extends Element {
     // the image when they no longer need to access it or draw it.
     ui.Image? clonedImage = _cachedImageInfo?.image.clone();
     if (clonedImage != null) {
+      bool isSizeChanged = true;
+      if (_renderImage != null && _renderImage!.image != null) {
+        isSizeChanged = _renderImage!.image!.width != clonedImage.width ||
+            _renderImage!.image!.height != clonedImage.height;
+      }
+
       _renderImage?.image = clonedImage;
-      _resizeImage();
+      if (isSizeChanged) {
+        _resizeImage();
+      }
     }
   }
 

--- a/webf/lib/src/rendering/flow.dart
+++ b/webf/lib/src/rendering/flow.dart
@@ -978,6 +978,8 @@ class RenderFlowLayout extends RenderLayoutBox {
             container.renderStyle.effectiveBorderBottomWidth.computedValue,
         maxScrollableCrossSizeOfChildren);
 
+    assert(maxScrollableMainSize.isFinite);
+    assert(maxScrollableCrossSize.isFinite);
     scrollableSize = Size(maxScrollableMainSize, maxScrollableCrossSize);
   }
 

--- a/webf/lib/src/rendering/overflow.dart
+++ b/webf/lib/src/rendering/overflow.dart
@@ -148,6 +148,8 @@ mixin RenderOverflowMixin on RenderBoxModelBase {
       return;
     }
 
+    assert(scrollableSize.isFinite);
+
     _scrollableSize = scrollableSize;
     _viewportSize = viewportSize;
     if (_scrollOffsetX != null) {


### PR DESCRIPTION
Prevent GIF images' individual frames from causing a relayout of the entire render object tree.