### PR TITLE
feat: add DOMContentLoaded API.

### DIFF
--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -729,6 +729,7 @@ class WebFController {
   GestureDispatcher gestureDispatcher = GestureDispatcher();
 
   LoadHandler? onLoad;
+  LoadHandler? onDOMContentLoaded;
 
   // Error handler when load bundle failed.
   LoadErrorHandler? onLoadError;
@@ -787,6 +788,7 @@ class WebFController {
     this.onCustomElementAttached,
     this.onCustomElementDetached,
     this.onLoad,
+    this.onDOMContentLoaded,
     this.onLoadError,
     this.onJSError,
     this.httpClientInterceptor,
@@ -1150,6 +1152,9 @@ class WebFController {
     EventTarget window = view.window;
     window.dispatchEvent(event);
     _view.document.dispatchEvent(event);
+    if (onDOMContentLoaded != null) {
+      onDOMContentLoaded!(this);
+    }
   }
 
   void _dispatchWindowLoadEvent() {

--- a/webf/lib/src/widget/webf.dart
+++ b/webf/lib/src/widget/webf.dart
@@ -51,6 +51,8 @@ class WebF extends StatefulWidget {
   final LoadErrorHandler? onLoadError;
 
   final LoadHandler? onLoad;
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
+  final LoadHandler? onDOMContentLoaded;
 
   final JSErrorHandler? onJSError;
 
@@ -104,6 +106,7 @@ class WebF extends StatefulWidget {
       this.bundle,
       this.onControllerCreated,
       this.onLoad,
+      this.onDOMContentLoaded,
       this.navigationDelegate,
       this.javaScriptChannel,
       this.background,
@@ -308,6 +311,7 @@ class WebFRootRenderObjectWidget extends MultiChildRenderObjectWidget {
         // Execute entrypoint when mount manually.
         autoExecuteEntrypoint: false,
         onLoad: _webfWidget.onLoad,
+        onDOMContentLoaded: _webfWidget.onDOMContentLoaded,
         onLoadError: _webfWidget.onLoadError,
         onJSError: _webfWidget.onJSError,
         methodChannel: _webfWidget.javaScriptChannel,


### PR DESCRIPTION
Add a Dart API callback when the DOMContentLoaded event is triggered.

```dart
WebF(
  onDOMContentLoaded: (controller) {
    print('dom content loaded ${ controller.view.document.isConnected}');
  },
),
```