### PR TITLE
fix: protect DOMTimers until the ExecutingContext exits.

### DIFF
--- a/bridge/core/frame/dom_timer.cc
+++ b/bridge/core/frame/dom_timer.cc
@@ -25,7 +25,8 @@ DOMTimer::DOMTimer(ExecutingContext* context, std::shared_ptr<QJSFunction> callb
     : context_(context), callback_(std::move(callback)), status_(TimerStatus::kPending), kind_(timer_kind) {}
 
 void DOMTimer::Fire() {
-  if (status_ == TimerStatus::kTerminated) return;
+  if (status_ == TimerStatus::kTerminated)
+    return;
 
   if (!callback_->IsFunction(context_->ctx()))
     return;

--- a/bridge/core/frame/dom_timer.cc
+++ b/bridge/core/frame/dom_timer.cc
@@ -25,6 +25,8 @@ DOMTimer::DOMTimer(ExecutingContext* context, std::shared_ptr<QJSFunction> callb
     : context_(context), callback_(std::move(callback)), status_(TimerStatus::kPending), kind_(timer_kind) {}
 
 void DOMTimer::Fire() {
+  if (status_ == TimerStatus::kTerminated) return;
+
   if (!callback_->IsFunction(context_->ctx()))
     return;
 
@@ -33,6 +35,11 @@ void DOMTimer::Fire() {
   if (returnValue.IsException()) {
     context_->HandleException(&returnValue);
   }
+}
+
+void DOMTimer::Terminate() {
+  callback_ = nullptr;
+  status_ = TimerStatus::kTerminated;
 }
 
 void DOMTimer::setTimerId(int32_t timerId) {

--- a/bridge/core/frame/dom_timer.h
+++ b/bridge/core/frame/dom_timer.h
@@ -14,7 +14,7 @@ namespace webf {
 class DOMTimer {
  public:
   enum TimerKind { kOnce, kMultiple };
-  enum TimerStatus { kPending, kExecuting, kFinished, kCanceled };
+  enum TimerStatus { kPending, kExecuting, kFinished, kCanceled, kTerminated };
 
   static std::shared_ptr<DOMTimer> create(ExecutingContext* context,
                                           const std::shared_ptr<QJSFunction>& callback,
@@ -23,6 +23,9 @@ class DOMTimer {
 
   // Trigger timer callback.
   void Fire();
+
+  // Mark this timer is terminated and free the underly callbacks.
+  void Terminate();
 
   TimerKind kind() const { return kind_; }
 

--- a/bridge/core/frame/dom_timer_coordinator.h
+++ b/bridge/core/frame/dom_timer_coordinator.h
@@ -35,6 +35,7 @@ class DOMTimerCoordinator {
 
  private:
   std::unordered_map<int, std::shared_ptr<DOMTimer>> active_timers_;
+  std::unordered_map<int, std::shared_ptr<DOMTimer>> terminated_timers;
 };
 
 }  // namespace webf

--- a/bridge/core/frame/window_or_worker_global_scope.cc
+++ b/bridge/core/frame/window_or_worker_global_scope.cc
@@ -31,7 +31,7 @@ static void handleTransientCallback(void* ptr, int32_t contextId, const char* er
   if (!context->IsContextValid())
     return;
 
-  if (timer->status() == DOMTimer::TimerStatus::kCanceled) {
+  if (timer->status() == DOMTimer::TimerStatus::kCanceled || timer->status() == DOMTimer::TimerStatus::kTerminated) {
     return;
   }
 
@@ -48,6 +48,10 @@ static void handlePersistentCallback(void* ptr, int32_t contextId, const char* e
 
   if (!context->IsContextValid())
     return;
+
+  if (timer->status() == DOMTimer::TimerStatus::kTerminated) {
+    return;
+  }
 
   if (timer->status() == DOMTimer::TimerStatus::kCanceled) {
     context->Timers()->removeTimeoutById(timer->timerId());
@@ -115,7 +119,7 @@ int WindowOrWorkerGlobalScope::setInterval(ExecutingContext* context,
   // Create a timer object to keep track timer callback.
   auto timer = DOMTimer::create(context, handler, DOMTimer::TimerKind::kMultiple);
 
-  uint32_t timerId =
+  int32_t timerId =
       context->dartMethodPtr()->setInterval(timer.get(), context->contextId(), handlePersistentCallback, timeout);
 
   // Register timerId.

--- a/webf/example/ios/Podfile
+++ b/webf/example/ios/Podfile
@@ -65,6 +65,7 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
       config_valid_archs(config)
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
     end
   end
   installer.pods_project.save

--- a/webf/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/webf/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -216,6 +216,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -230,6 +231,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/webf/example/ios/Runner/Info.plist
+++ b/webf/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
In some rare cases, DOMTimer may be accessed even if the timer has been canceled and removed from the DOMCoordinator. This could cause a BAD ACCESS crash since the timer's memory has been freed.

In this patch, we terminate the timer but do not immediately free it.