### PR TITLE
Feat: optimize image load

### DIFF
--- a/bridge/core/dart_methods.cc
+++ b/bridge/core/dart_methods.cc
@@ -23,7 +23,7 @@ webf::DartMethodPointer::DartMethodPointer(const uint64_t* dart_methods, int32_t
   create_binding_object = reinterpret_cast<CreateBindingObject>(dart_methods[i++]);
 
 #if ENABLE_PROFILE
-  dartMethodPointer->getPerformanceEntries = reinterpret_cast<GetPerformanceEntries>(dart_methods[i++]);
+  getPerformanceEntries = reinterpret_cast<GetPerformanceEntries>(dart_methods[i++]);
 #else
   i++;
 #endif

--- a/integration_tests/specs/css/css-flexbox/flex_shrink.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_shrink.ts
@@ -803,7 +803,7 @@ describe('flexbox flex-shrink', () => {
       {
         style: {
           "display": "flex",
-          "width": "100px",
+          "width": "200px",
           "height": "100px",
         },
       },

--- a/integration_tests/specs/dom/elements/img.ts
+++ b/integration_tests/specs/dom/elements/img.ts
@@ -154,13 +154,13 @@ describe('Tags img', () => {
     }) as HTMLImageElement;
     BODY.appendChild(img);
     let src = img.src;
-    expect(src).toBe('http://localhost:4567/public/assets/rabbit.png');
+    expect(src).toBe(`http://localhost:${location.port}/public/assets/rabbit.png`);
     // have to wait for asset load?
     await snapshot(0.1);
     img.src = 'assets/solidblue.png';
     await snapshot(0.1);
     src = img.src;
-    expect(src).toBe('http://localhost:4567/public/assets/solidblue.png');
+    expect(src).toBe(`http://localhost:${location.port}/public/assets/solidblue.png`);
     done();
   });
 

--- a/integration_tests/specs/dom/elements/script.ts
+++ b/integration_tests/specs/dom/elements/script.ts
@@ -17,7 +17,7 @@ describe('script element', () => {
     script.onerror = () => {
       done();
     };
-    script.src = 'http://musttofail.com/404';
+    script.src = '/404';
   });
 
   it('async script execute in delayed order', async (done) => {

--- a/webf/lib/src/bridge/binding.dart
+++ b/webf/lib/src/bridge/binding.dart
@@ -135,27 +135,16 @@ abstract class BindingBridge {
   }
 
   static void listenEvent(EventTarget target, String type) {
-    assert(_debugShouldNotListenMultiTimes(target, type),
-        'Failed to listen event \'$type\' for $target, for which is already bound.');
-    target.addEventListener(type, _dispatchEventToNative);
+    if (!hasListener(target, type)) {
+      target.addEventListener(type, _dispatchEventToNative);
+    }
   }
 
   static void unlistenEvent(EventTarget target, String type) {
-    assert(_debugShouldNotUnlistenEmpty(target, type),
-        'Failed to unlisten event \'$type\' for $target, for which is already unbound.');
     target.removeEventListener(type, _dispatchEventToNative);
   }
 
-  static bool _debugShouldNotListenMultiTimes(EventTarget target, String type) {
-    Map<String, List<EventHandler>> eventHandlers = target.getEventHandlers();
-    List<EventHandler>? handlers = eventHandlers[type];
-    if (handlers != null) {
-      return !handlers.contains(_dispatchEventToNative);
-    }
-    return true;
-  }
-
-  static bool _debugShouldNotUnlistenEmpty(EventTarget target, String type) {
+  static bool hasListener(EventTarget target, String type) {
     Map<String, List<EventHandler>> eventHandlers = target.getEventHandlers();
     List<EventHandler>? handlers = eventHandlers[type];
     if (handlers != null) {

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -168,10 +168,7 @@ class ImageElement extends Element {
     // Stop and remove image stream reference.
     _stopListeningStream(keepStreamAlive: true);
     _cachedImageStream = null;
-
-    // Dispose [ImageStreamCompleter].
-    _completerHandle?.dispose();
-    _completerHandle = null;
+    _currentImageProvider = null;
 
     // Remove cached image info.
     _cachedImageInfo = null;

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -604,7 +604,7 @@ class ImageElement extends Element {
   void _stylePropertyChanged(String property, String? original, String present, { String? baseHref }) {
     if (property == WIDTH || property == HEIGHT) {
       // Resize image
-      if (_shouldScaling) {
+      if (_shouldScaling && _resolvedUri != null) {
         _decode(updateImageProvider: true);
       } else {
         _resizeImage();

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -530,10 +530,14 @@ class ImageElement extends Element {
     // attached to correct renderBoxModel
     if (!_isInLazyLoading) {
       // Image dimensions (width or height) should specified for performance when lazy-load.
-      if (_shouldLazyLoading) {
+      // If the _completerHandle are not null, there must be a imageProvider available in the imageCache.
+      if (_shouldLazyLoading && _completerHandle == null) {
         RenderReplaced? renderReplaced = renderBoxModel as RenderReplaced?;
         renderReplaced
           ?..isInLazyRendering = true
+        // Expand the intersecting area to preload images before they become visible to users.
+          ..intersectPadding = Rect.fromLTRB(ui.window.physicalSize.width, ui.window.physicalSize.height,
+              ui.window.physicalSize.width, ui.window.physicalSize.height)
           // When detach renderer, all listeners will be cleared.
           ..addIntersectionChangeListener(_handleIntersectionChange);
       } else {

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -212,7 +212,6 @@ class ImageElement extends Element {
     _completerHandle?.dispose();
     _completerHandle = null;
     _cachedImageInfo = null;
-    await _currentImageProvider?.evict();
     _currentImageProvider = null;
   }
 

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -475,9 +475,9 @@ class ImageElement extends Element {
   void _attachImage() {
     // Creates a disposable handle to this image. Holders of this [ui.Image] must dispose of
     // the image when they no longer need to access it or draw it.
-    ui.Image? clonedImage = _cachedImageInfo?.image.clone();
-    if (clonedImage != null) {
-      _renderImage?.image = clonedImage;
+    ui.Image? image = _cachedImageInfo?.image;
+    if (image != null) {
+      _renderImage?.image = image;
       _resizeImage();
     }
   }

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -185,6 +185,7 @@ class ImageElement extends Element {
     if (renderBoxModel != null) {
       RenderReplaced renderReplaced = renderBoxModel as RenderReplaced;
       renderReplaced.child = null;
+      _renderImage?.image = null;
 
       ownerDocument.inactiveRenderObjects.add(_renderImage);
       _renderImage = null;

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -424,8 +424,18 @@ class ImageElement extends Element {
       }
 
       // Try to make sure that this image can be encoded into a smaller size.
-      int? cachedWidth = width > 0 && width.isFinite ? (width * ui.window.devicePixelRatio).toInt() : null;
-      int? cachedHeight = height > 0 && height.isFinite ? (height * ui.window.devicePixelRatio).toInt() : null;
+      int? cachedWidth = renderStyle.width.value != null && width > 0 && width.isFinite ? (width * ui.window.devicePixelRatio).toInt() : null;
+      int? cachedHeight = renderStyle.height.value != null && height > 0 && height.isFinite ? (height * ui.window.devicePixelRatio).toInt() : null;
+
+      if (cachedWidth != null && cachedHeight != null) {
+        // If a image with the same URL has a fixed size, attempt to remove the previous unsized imageProvider from imageCache.
+        BoxFitImageKey previousUnSizedKey = BoxFitImageKey(
+          url: _resolvedUri!,
+          configuration: ImageConfiguration.empty,
+        );
+        PaintingBinding.instance.imageCache.evict(previousUnSizedKey, includeLive: true);
+      }
+
       ImageConfiguration imageConfiguration = _shouldScaling && cachedWidth != null && cachedHeight != null
           ? ImageConfiguration(size: Size(cachedWidth.toDouble(), cachedHeight.toDouble()))
           : ImageConfiguration.empty;

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:webf/css.dart';
 import 'package:webf/dom.dart';
+import 'package:webf/bridge.dart';
 import 'package:webf/foundation.dart';
 import 'package:webf/painting.dart';
 import 'package:webf/rendering.dart';
@@ -89,7 +90,12 @@ class ImageElement extends Element {
 
   ImageStreamCompleterHandle? _completerHandle;
 
-  ImageElement([BindingContext? context]) : super(context) {}
+  ImageElement([BindingContext? context]) : super(context) {
+    // Add default event listener to make sure load or error event can be fired to the native side to release the keepAlive
+    // handler of HTMLImageElement.
+    BindingBridge.listenEvent(this, 'load');
+    BindingBridge.listenEvent(this, 'error');
+  }
 
   @override
   bool get isReplacedElement => true;

--- a/webf/lib/src/rendering/box_model.dart
+++ b/webf/lib/src/rendering/box_model.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui';
 
+import 'dart:developer' show Timeline;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -1174,22 +1175,26 @@ class RenderBoxModel extends RenderBox
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (kProfileMode && PerformanceTiming.enabled()) {
-      childPaintDuration = 0;
-      PerformanceTiming.instance().mark(PERF_PAINT_START, uniqueId: hashCode);
+    if (!kReleaseMode) {
+      Timeline.startSync(
+        'RenderBoxModel paint',
+        arguments: {
+          'ownerElement': renderStyle.target.toString()
+        },
+      );
     }
 
     if (!shouldPaint) {
-      if (kProfileMode && PerformanceTiming.enabled()) {
-        PerformanceTiming.instance().mark(PERF_PAINT_END, uniqueId: hashCode);
+      if (!kReleaseMode) {
+        Timeline.finishSync();
       }
       return;
     }
 
     paintBoxModel(context, offset);
-    if (kProfileMode && PerformanceTiming.enabled()) {
-      int amendEndTime = DateTime.now().microsecondsSinceEpoch - childPaintDuration;
-      PerformanceTiming.instance().mark(PERF_PAINT_END, uniqueId: hashCode, startTime: amendEndTime);
+
+    if (!kReleaseMode) {
+      Timeline.finishSync();
     }
   }
 

--- a/webf/lib/src/rendering/webf_render_list.dart
+++ b/webf/lib/src/rendering/webf_render_list.dart
@@ -4,6 +4,8 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:webf/dom.dart';
+import 'package:webf/rendering.dart';
 
 
 /// copy from flutter RenderSliverList
@@ -232,10 +234,11 @@ class WebFRenderSliverList extends RenderSliverMultiBoxAdaptor {
             return false;
           }
         } else {
-          final DateTime record3 = DateTime.now();
-          // Lay out the child.
-          child!.layout(childConstraints, parentUsesSize: true);
-          print('layout sliver item use time: ${DateTime.now().microsecondsSinceEpoch - record3.microsecondsSinceEpoch}');
+          RenderBoxModel realChild = (child as RenderSliverRepaintProxy).child as RenderBoxModel;
+          // Layout the child.
+          if (realChild.needsLayout) {
+            child!.layout(childConstraints, parentUsesSize: true);
+          }
         }
         trailingChildWithLayout = child;
       }


### PR DESCRIPTION
Significantly optimize the image loading strategy and fix potential memory leaks.

1. [x] Collaborate with Flutter's ImageCache. Each HTMLImageElement will have a reference to an ImageProvider. If another HTMLElement uses the same URL, it will obtain the same ImageProvider from the ImageCache, preventing repeated requests and decoding.
2. [x] If an HTMLImageElement has a fixed size (both width and height are defined), a new ImageProvider with a fixed size will replace the previous unsized ImageProvider. When an ImageProvider has a fixed size, it resizes the image to a suitable size to reduce memory usage if the image is larger than its actual display size.
3. [x] If an HTMLImageElement's renderObject is detached from the RenderObject tree, an ImageStreamCompleterHandle will be created to keep the ImageProvider alive in the imageCache. When the HTMLImageElement is disposed of by the quickjs GC, the ImageStreamCompleterHandle will also be disposed, and the imageProvider in imageCache will be dereferenced. When all HTMLImageElement and ImageStreamCompleterHandle are disposed of and there are no listeners are attached to this imageProvider in imageCache. The imageProvider will dispose itself and release the actual ui.Image instance to free up the underly memory in the Flutter engine.
4. [x] HTMLImage with loading=lazy only loads when it first appears in the user's viewport. Once the image has been loaded, it will be stored in the ImageCache. When another image with the same URL is attached to the rendering tree, the image can appear immediately without loading. 