### PR TITLE
feat: validate bytecode cache with CRC32 checksum.

### DIFF
--- a/webf/pubspec.yaml
+++ b/webf/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   source_span: ^1.9.0 # Pure dart module.
   connectivity_plus: ^3.0.3 # No AndroidX used.
   shared_preferences: 2.0.17 # No AndroidX used.
+  archive: ^3.3.7 # Pure dart module.
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In some rare cases, the cached bytecode may be corrupt. To ensure the cached bytecode is correct, add a checksum using the CRC32 algorithm.