### PR TITLE
fix: fix crashed when access global functions with multiple parameters.

### DIFF
--- a/bridge/scripts/code_generator/src/idl/generateSource.ts
+++ b/bridge/scripts/code_generator/src/idl/generateSource.ts
@@ -336,7 +336,7 @@ function generateOptionalInitBody(blob: IDLBlob, declare: FunctionDeclaration, a
   if (declare.returnTypeMode?.dartImpl) {
     call = generateDartImplCallCode(blob, declare, declare.args.slice(0, argsIndex + 1));
   } else if (options.isInstanceMethod) {
-    call = `auto* self = toScriptWrappable<${getClassName(blob)}>(this_val);
+    call = `auto* self = toScriptWrappable<${getClassName(blob)}>(JS_IsUndefined(this_val) ? context->Global() : this_val);
 ${returnValueAssignment} self->${generateCallMethodName(declare.name)}(${[...previousArguments, `args_${argument.name}`, 'exception_state'].join(',')});`;
   } else {
     call = `${returnValueAssignment} ${getClassName(blob)}::${generateCallMethodName(declare.name)}(context, ${[...previousArguments, `args_${argument.name}`].join(',')}, exception_state);`;

--- a/integration_tests/specs/window/global.ts
+++ b/integration_tests/specs/window/global.ts
@@ -42,6 +42,12 @@ describe('window', () => {
     expect(window.self).toBe(window);
   });
 
+  it('call global function should set this to globalThis', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    getComputedStyle(div, null);
+  });
+
   it('window should work with addEventListener', async (done) => {
     const div = document.createElement('div');
     div.style.width = '100px';


### PR DESCRIPTION
The code_generator does not generate the correct code for accessing 'this' in JavaScript functions when the parameter count is greater than 1.

<img width="1497" alt="image" src="https://github.com/openwebf/webf/assets/4409743/e1b88b85-6622-44ec-bf1c-fbed4739526d">

 