### PR TITLE
fix: fix template element's content property cause mem leaks.

### DIFF
--- a/bridge/core/html/html_template_element.cc
+++ b/bridge/core/html/html_template_element.cc
@@ -22,6 +22,10 @@ DocumentFragment* HTMLTemplateElement::ContentInternal() const {
   return content_.Get();
 }
 
+void HTMLTemplateElement::Trace(webf::GCVisitor* visitor) const {
+  visitor->Trace(content_);
+}
+
 bool HTMLTemplateElement::IsAttributeDefinedInternal(const AtomicString& key) const {
   return QJSHTMLTemplateElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
 }

--- a/bridge/core/html/html_template_element.h
+++ b/bridge/core/html/html_template_element.h
@@ -21,6 +21,8 @@ class HTMLTemplateElement : public HTMLElement {
 
   bool IsAttributeDefinedInternal(const AtomicString& key) const override;
 
+  void Trace(webf::GCVisitor* visitor) const override;
+
  private:
   DocumentFragment* ContentInternal() const;
   mutable Member<DocumentFragment> content_;

--- a/integration_tests/specs/dom/elements/template.ts
+++ b/integration_tests/specs/dom/elements/template.ts
@@ -15,4 +15,17 @@ describe('Tags template', () => {
     expect(t.innerHTML).toBe('');
     await snapshot();
   });
+
+  it('should avoid leaks when massive elements in template element', async () => {
+    const t = document.createElement('template')
+    const template = t.content;
+    const element = document.createElement('div');
+    element.innerHTML = `<ul>
+<li><div><span>1</span></div></li>
+<li><div><span>2</span></div></li>
+<li><div><span>3</span></div></li>
+</ul>`;
+    template.appendChild(element);
+    document.body.appendChild(template);
+  });
 });


### PR DESCRIPTION
Fix the DocumentFragment instance leaks when GC template elements.