### PR TITLE
Comparison without operator overload failure

### DIFF
--- a/bridge/bindings/qjs/js_event_listener.h
+++ b/bridge/bindings/qjs/js_event_listener.h
@@ -30,7 +30,9 @@ class JSEventListener final : public JSBasedEventListener {
 
   bool Matches(const EventListener& other) const override {
     const auto* other_listener = DynamicTo<JSEventListener>(other);
-    return other_listener && event_listener_ == other_listener->event_listener_;
+    return other_listener && event_listener_.get() && other_listener->event_listener_.get() &&
+         event_listener_.get() == other_listener->event_listener_.get();
+
   }
 
   void Trace(GCVisitor* visitor) const override;

--- a/bridge/bindings/qjs/js_event_listener.h
+++ b/bridge/bindings/qjs/js_event_listener.h
@@ -30,7 +30,7 @@ class JSEventListener final : public JSBasedEventListener {
 
   bool Matches(const EventListener& other) const override {
     const auto* other_listener = DynamicTo<JSEventListener>(other);
-    return other_listener && event_listener_.get() == other_listener->event_listener_.get();
+    return other_listener && event_listener_ == other_listener->event_listener_;
   }
 
   void Trace(GCVisitor* visitor) const override;

--- a/bridge/bindings/qjs/js_event_listener.h
+++ b/bridge/bindings/qjs/js_event_listener.h
@@ -30,9 +30,7 @@ class JSEventListener final : public JSBasedEventListener {
 
   bool Matches(const EventListener& other) const override {
     const auto* other_listener = DynamicTo<JSEventListener>(other);
-    return other_listener && event_listener_.get() && other_listener->event_listener_.get() &&
-         event_listener_.get() == other_listener->event_listener_.get();
-
+    return other_listener && *event_listener_ == *other_listener->event_listener_;
   }
 
   void Trace(GCVisitor* visitor) const override;

--- a/bridge/bindings/qjs/js_event_listener.h
+++ b/bridge/bindings/qjs/js_event_listener.h
@@ -30,7 +30,7 @@ class JSEventListener final : public JSBasedEventListener {
 
   bool Matches(const EventListener& other) const override {
     const auto* other_listener = DynamicTo<JSEventListener>(other);
-    return other_listener && *event_listener_ == *other_listener->event_listener_;
+    return other_listener && event_listener_.get() == other_listener->event_listener_.get();
   }
 
   void Trace(GCVisitor* visitor) const override;

--- a/bridge/bindings/qjs/qjs_function.h
+++ b/bridge/bindings/qjs/qjs_function.h
@@ -42,8 +42,8 @@ class QJSFunction {
   // https://webidl.spec.whatwg.org/#invoke-a-callback-function
   ScriptValue Invoke(JSContext* ctx, const ScriptValue& this_val, int32_t argc, ScriptValue* arguments);
 
-  bool operator==(const QJSFunction& other) {
-    return JS_VALUE_GET_PTR(function_) == JS_VALUE_GET_PTR(other.function_);
+  friend bool operator==(const QJSFunction& lhs, const QJSFunction& rhs) {
+    return JS_VALUE_GET_PTR(lhs.function_) == JS_VALUE_GET_PTR(rhs.function_);
   };
 
   void Trace(GCVisitor* visitor) const;


### PR DESCRIPTION
Using .get() allows us to compare the raw value of memory address underlying each, which would then make the comparison valid

Fixes https://github.com/openwebf/webf/issues/351