### PR TITLE
Feat: add `append()`, `prepend()`, `before()` and `after()` support.

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -417,6 +417,7 @@ if ($ENV{WEBF_JS_ENGINE} MATCHES "quickjs")
     out/qjs_event_init.cc
     out/qjs_event_target.cc
     out/qjs_node.cc
+    out/qjs_union_dom_stringnode.cc
     out/qjs_document.cc
     out/qjs_element.cc
     out/qjs_dom_token_list.cc

--- a/bridge/bindings/qjs/converter_impl.h
+++ b/bridge/bindings/qjs/converter_impl.h
@@ -315,9 +315,9 @@ struct Converter<IDLSequence<T>> : public ConverterBase<IDLSequence<T>> {
   };
 
   static ImplType ArgumentsValue(ExecutingContext* context,
-                                             JSValue value,
-                                             uint32_t argv_index,
-                                             ExceptionState& exception_state) {
+                                 JSValue value,
+                                 uint32_t argv_index,
+                                 ExceptionState& exception_state) {
     assert(!JS_IsException(value));
     if (JS_IsArray(context->ctx(), value)) {
       return FromValue(context->ctx(), value, exception_state);

--- a/bridge/bindings/qjs/converter_impl.h
+++ b/bridge/bindings/qjs/converter_impl.h
@@ -314,6 +314,20 @@ struct Converter<IDLSequence<T>> : public ConverterBase<IDLSequence<T>> {
     return v;
   };
 
+  static ImplType ArgumentsValue(ExecutingContext* context,
+                                             JSValue value,
+                                             uint32_t argv_index,
+                                             ExceptionState& exception_state) {
+    assert(!JS_IsException(value));
+    if (JS_IsArray(context->ctx(), value)) {
+      return FromValue(context->ctx(), value, exception_state);
+    }
+    ImplType v;
+    exception_state.ThrowException(context->ctx(), ErrorType::TypeError,
+                                   ExceptionMessage::ArgumentNotOfType(argv_index, "Array"));
+    return v;
+  }
+
   static JSValue ToValue(JSContext* ctx, ImplType value) {
     JSValue array = JS_NewArray(ctx);
     JS_SetPropertyStr(ctx, array, "length", Converter<IDLInt64>::ToValue(ctx, value.size()));

--- a/bridge/core/dom/character_data.d.ts
+++ b/bridge/core/dom/character_data.d.ts
@@ -1,6 +1,7 @@
 import {Node} from "./node";
+import {ChildNode} from "./child_node";
 
-export interface CharacterData extends Node {
+export interface CharacterData extends Node, ChildNode {
   data: string;
   readonly length: int64;
   new(): void;

--- a/bridge/core/dom/child_node.d.ts
+++ b/bridge/core/dom/child_node.d.ts
@@ -1,0 +1,11 @@
+// @ts-ignore
+import {HTMLAllCollection} from "../html/html_all_collection";
+import {Element} from "./element";
+import {Node} from "./node";
+
+// @ts-ignore
+@Mixin()
+export interface ChildNode {
+  before(...node: (string | Node)[]): void;
+  after(...node: (string | Node) []): void;
+}

--- a/bridge/core/dom/comment.h
+++ b/bridge/core/dom/comment.h
@@ -25,6 +25,11 @@ class Comment : public CharacterData {
   Node* Clone(Document&, CloneChildrenFlag) const override;
 };
 
+template <>
+struct DowncastTraits<Comment> {
+  static bool AllowFrom(const Node& node) { return node.IsOtherNode(); }
+};
+
 }  // namespace webf
 
 #endif  // BRIDGE_COMMENT_H

--- a/bridge/core/dom/document.d.ts
+++ b/bridge/core/dom/document.d.ts
@@ -10,8 +10,9 @@ import {Event} from "./events/event";
 import {HTMLAllCollection} from "../html/html_all_collection";
 import {IDLEventHandler} from "../frame/window_event_handlers";
 import {Window} from "../frame/window";
+import {ParentNode} from "./parent_node";
 
-interface Document extends Node {
+interface Document extends Node, ParentNode {
   readonly all: HTMLAllCollection;
   body: HTMLBodyElement | null;
   cookie: DartImpl<string>;

--- a/bridge/core/dom/document_fragment.d.ts
+++ b/bridge/core/dom/document_fragment.d.ts
@@ -1,5 +1,6 @@
 import { Node } from './node';
+import {ParentNode} from "./parent_node";
 
-interface DocumentFragment extends Node {
+interface DocumentFragment extends Node, ParentNode {
   new(): DocumentFragment;
 }

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -9,6 +9,7 @@
 #include "bindings/qjs/script_promise.h"
 #include "bindings/qjs/script_promise_resolver.h"
 #include "built_in_string.h"
+#include "comment.h"
 #include "core/dom/document_fragment.h"
 #include "core/fileapi/blob.h"
 #include "core/html/html_template_element.h"
@@ -443,6 +444,8 @@ std::string Element::innerHTML() {
       s += element->outerHTML();
     } else if (auto* text = DynamicTo<Text>(child)) {
       s += text->data().ToStdString(ctx());
+    } else if (auto* comment = DynamicTo<Comment>(child)) {
+      s += "<!--" + comment->data().ToStdString(ctx()) + "-->";
     }
     child = child->nextSibling();
   }

--- a/bridge/core/dom/element.d.ts
+++ b/bridge/core/dom/element.d.ts
@@ -4,8 +4,9 @@ import {ScrollToOptions} from "./scroll_to_options";
 import { ElementAttributes } from './legacy/element_attributes';
 import {CSSStyleDeclaration} from "../css/css_style_declaration";
 import {ParentNode} from "./parent_node";
+import {ChildNode} from "./child_node";
 
-interface Element extends Node, ParentNode {
+interface Element extends Node, ParentNode, ChildNode {
   id: string;
   className: string;
   readonly classList: DOMTokenList;

--- a/bridge/core/dom/node.cc
+++ b/bridge/core/dom/node.cc
@@ -257,6 +257,18 @@ void Node::append(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nod
     this_node->AppendChild(node, exception_state);
 }
 
+void Node::append(ExceptionState& exception_state) {
+  append(std::vector<std::shared_ptr<QJSUnionDomStringNode>>(), exception_state);
+}
+
+void Node::before(ExceptionState& exception_state) {
+  before(std::vector<std::shared_ptr<QJSUnionDomStringNode>>(), exception_state);
+}
+
+void Node::after(webf::ExceptionState& exception_state) {
+  after(std::vector<std::shared_ptr<QJSUnionDomStringNode>>(), exception_state);
+}
+
 static bool IsNodeInNodes(const Node* const node, const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes) {
   for (const std::shared_ptr<QJSUnionDomStringNode>& node_or_string : nodes) {
     if (node_or_string->IsNode() && node_or_string->GetAsNode() == node)

--- a/bridge/core/dom/node.cc
+++ b/bridge/core/dom/node.cc
@@ -1,28 +1,28 @@
 /*
-* Copyright (C) 1999 Lars Knoll (knoll@kde.org)
-*           (C) 1999 Antti Koivisto (koivisto@kde.org)
-*           (C) 2001 Dirk Mueller (mueller@kde.org)
-* Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Apple Inc. All
-* rights reserved.
-* Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
-* Copyright (C) 2009 Torch Mobile Inc. All rights reserved.
-* (http://www.torchmobile.com/)
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Library General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* Library General Public License for more details.
-*
-* You should have received a copy of the GNU Library General Public License
-* along with this library; see the file COPYING.LIB.  If not, write to
-* the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301, USA.
-*/
+ * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
+ *           (C) 1999 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2001 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Apple Inc. All
+ * rights reserved.
+ * Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
+ * Copyright (C) 2009 Torch Mobile Inc. All rights reserved.
+ * (http://www.torchmobile.com/)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
 
 /*
  * Copyright (C) 2019-2022 The Kraken authors. All rights reserved.
@@ -233,7 +233,8 @@ static Node* ConvertNodesIntoNode(const Node* parent,
   return fragment;
 }
 
-void Node::prepend(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, webf::ExceptionState& exception_state) {
+void Node::prepend(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes,
+                   webf::ExceptionState& exception_state) {
   auto* this_node = DynamicTo<ContainerNode>(this);
   if (!this_node) {
     exception_state.ThrowException(ctx(), ErrorType::TypeError, "This node type does not support this method.");
@@ -244,7 +245,8 @@ void Node::prepend(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& no
     this_node->InsertBefore(node, this_node->firstChild(), exception_state);
 }
 
-void Node::append(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, webf::ExceptionState& exception_state) {
+void Node::append(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes,
+                  webf::ExceptionState& exception_state) {
   auto* this_node = DynamicTo<ContainerNode>(this);
   if (!this_node) {
     exception_state.ThrowException(ctx(), ErrorType::TypeError, "This node type does not support this method.");
@@ -263,7 +265,8 @@ static bool IsNodeInNodes(const Node* const node, const std::vector<std::shared_
   return false;
 }
 
-static Node* FindViablePreviousSibling(const Node& node, const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes) {
+static Node* FindViablePreviousSibling(const Node& node,
+                                       const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes) {
   for (Node* sibling = node.previousSibling(); sibling; sibling = sibling->previousSibling()) {
     if (!IsNodeInNodes(sibling, nodes))
       return sibling;
@@ -279,7 +282,8 @@ static Node* FindViableNextSibling(const Node& node, const std::vector<std::shar
   return nullptr;
 }
 
-void Node::before(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, webf::ExceptionState& exception_state) {
+void Node::before(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes,
+                  webf::ExceptionState& exception_state) {
   ContainerNode* parent = parentNode();
   if (!parent)
     return;
@@ -290,7 +294,8 @@ void Node::before(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nod
   }
 }
 
-void Node::after(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, webf::ExceptionState& exception_state) {
+void Node::after(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes,
+                 webf::ExceptionState& exception_state) {
   ContainerNode* parent = parentNode();
   if (!parent)
     return;

--- a/bridge/core/dom/node.h
+++ b/bridge/core/dom/node.h
@@ -13,6 +13,7 @@
 #include "foundation/macros.h"
 #include "node_data.h"
 #include "tree_scope.h"
+#include "qjs_union_dom_stringnode.h"
 
 namespace webf {
 
@@ -27,6 +28,7 @@ class DocumentFragment;
 class ContainerNode;
 class NodeList;
 class EventTargetDataObject;
+class QJSUnionDomStringNode;
 
 enum class CustomElementState : uint32_t {
   // https://dom.spec.whatwg.org/#concept-element-custom-element-state
@@ -96,6 +98,11 @@ class Node : public EventTarget {
   bool hasChildren() const { return firstChild(); }
   Node* cloneNode(bool deep, ExceptionState&) const;
   Node* cloneNode(ExceptionState&) const;
+
+  void prepend(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
+  void append(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
+  void before(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
+  void after(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
 
   // https://dom.spec.whatwg.org/#concept-node-clone
   virtual Node* Clone(Document&, CloneChildrenFlag) const = 0;

--- a/bridge/core/dom/node.h
+++ b/bridge/core/dom/node.h
@@ -12,8 +12,8 @@
 #include "events/event_target.h"
 #include "foundation/macros.h"
 #include "node_data.h"
-#include "tree_scope.h"
 #include "qjs_union_dom_stringnode.h"
+#include "tree_scope.h"
 
 namespace webf {
 

--- a/bridge/core/dom/node.h
+++ b/bridge/core/dom/node.h
@@ -100,9 +100,13 @@ class Node : public EventTarget {
   Node* cloneNode(ExceptionState&) const;
 
   void prepend(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
+  void prepend(ExceptionState& exception_state);
   void append(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
+  void append(ExceptionState& exception_state);
   void before(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
+  void before(ExceptionState& exception_state);
   void after(const std::vector<std::shared_ptr<QJSUnionDomStringNode>>& nodes, ExceptionState& exception_state);
+  void after(ExceptionState& exception_state);
 
   // https://dom.spec.whatwg.org/#concept-node-clone
   virtual Node* Clone(Document&, CloneChildrenFlag) const = 0;
@@ -116,6 +120,7 @@ class Node : public EventTarget {
 
   // Other methods (not part of DOM)
   [[nodiscard]] FORCE_INLINE bool IsTextNode() const { return GetDOMNodeType() == DOMNodeType::kText; }
+  [[nodiscard]] FORCE_INLINE bool IsOtherNode() const { return GetDOMNodeType() == DOMNodeType::kOther; }
   [[nodiscard]] FORCE_INLINE bool IsContainerNode() const { return GetFlag(kIsContainerFlag); }
   [[nodiscard]] FORCE_INLINE bool IsElementNode() const { return GetDOMNodeType() == DOMNodeType::kElement; }
   [[nodiscard]] FORCE_INLINE bool IsDocumentFragment() const {

--- a/bridge/core/dom/parent_node.cc
+++ b/bridge/core/dom/parent_node.cc
@@ -22,8 +22,7 @@ std::vector<Element*> ParentNode::children(ContainerNode& node) {
 
 int64_t ParentNode::childElementCount(webf::ContainerNode& node) {
   unsigned count = 0;
-  for (Element* child = ElementTraversal::FirstChild(node); child;
-       child = ElementTraversal::NextSibling(*child))
+  for (Element* child = ElementTraversal::FirstChild(node); child; child = ElementTraversal::NextSibling(*child))
     ++count;
   return count;
 }

--- a/bridge/core/dom/parent_node.cc
+++ b/bridge/core/dom/parent_node.cc
@@ -20,4 +20,12 @@ std::vector<Element*> ParentNode::children(ContainerNode& node) {
   return node.Children();
 }
 
+int64_t ParentNode::childElementCount(webf::ContainerNode& node) {
+  unsigned count = 0;
+  for (Element* child = ElementTraversal::FirstChild(node); child;
+       child = ElementTraversal::NextSibling(*child))
+    ++count;
+  return count;
+}
+
 }  // namespace webf

--- a/bridge/core/dom/parent_node.d.ts
+++ b/bridge/core/dom/parent_node.d.ts
@@ -12,7 +12,5 @@ export interface ParentNode {
   readonly childElementCount: int64;
 
   prepend(...node: (string | Node)[]): void;
-  append(...node: (string | Node)[]): void;
-  before(...node: (string | Node)[]): void;
-  after(...node: (string | Node)[]): void;
+  append(...node: (string | Node) []): void;
 }

--- a/bridge/core/dom/parent_node.d.ts
+++ b/bridge/core/dom/parent_node.d.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import {HTMLAllCollection} from "../html/html_all_collection";
 import {Element} from "./element";
+import {Node} from "./node";
 
 // @ts-ignore
 @Mixin()
@@ -8,4 +9,10 @@ export interface ParentNode {
   readonly firstElementChild: Element | null;
   readonly lastElementChild: Element | null;
   readonly children: Element[];
+  readonly childElementCount: int64;
+
+  prepend(...node: (string | Node)[]): void;
+  append(...node: (string | Node)[]): void;
+  before(...node: (string | Node)[]): void;
+  after(...node: (string | Node)[]): void;
 }

--- a/bridge/core/dom/parent_node.h
+++ b/bridge/core/dom/parent_node.h
@@ -21,6 +21,7 @@ class ParentNode {
   static Element* firstElementChild(ContainerNode& node);
   static Element* lastElementChild(ContainerNode& node);
   static std::vector<Element*> children(ContainerNode& node);
+  static int64_t childElementCount(ContainerNode& node);
 };
 
 }  // namespace webf

--- a/bridge/core/dom/parent_node.h
+++ b/bridge/core/dom/parent_node.h
@@ -6,6 +6,7 @@
 #ifndef BRIDGE_BINDINGS_QJS_BOM_PARENT_NODE_H_
 #define BRIDGE_BINDINGS_QJS_BOM_PARENT_NODE_H_
 
+#include <cstdint>
 #include <vector>
 #include "foundation/macros.h"
 

--- a/bridge/core/html/canvas/canvas_rendering_context_2d.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context_2d.cc
@@ -5,9 +5,9 @@
 #include "canvas_rendering_context_2d.h"
 #include "binding_call_methods.h"
 #include "canvas_gradient.h"
-#include "foundation/native_value_converter.h"
-#include "core/html/html_image_element.h"
 #include "core/html/canvas/html_canvas_element.h"
+#include "core/html/html_image_element.h"
+#include "foundation/native_value_converter.h"
 
 namespace webf {
 

--- a/bridge/core/html/canvas/canvas_rendering_context_2d.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context_2d.cc
@@ -6,6 +6,8 @@
 #include "binding_call_methods.h"
 #include "canvas_gradient.h"
 #include "foundation/native_value_converter.h"
+#include "core/html/html_image_element.h"
+#include "core/html/canvas/html_canvas_element.h"
 
 namespace webf {
 

--- a/bridge/polyfill/src/dom.ts
+++ b/bridge/polyfill/src/dom.ts
@@ -12,17 +12,6 @@ document.documentElement.appendChild(head);
 let body = document.createElement('body');
 document.documentElement.appendChild(body);
 
-// @ts-ignore
-class SVGElement extends Element {
-  constructor() {
-    super();
-  }
-}
-
-Object.defineProperty(window, 'SVGElement', {
-  value: SVGElement
-});
-
 // SVGMatrix are equal to DOMMatrix.
 Object.defineProperty(window, 'SVGMatrix', {
   value: DOMMatrix

--- a/bridge/scripts/code_generator/src/idl/analyzer.ts
+++ b/bridge/scripts/code_generator/src/idl/analyzer.ts
@@ -149,6 +149,11 @@ function getParameterBaseType(type: ts.TypeNode, mode?: ParameterMode): Paramete
 }
 
 function getParameterType(type: ts.TypeNode, unionTypeCollector: UnionTypeCollector, mode?: ParameterMode): ParameterType {
+  if (type.kind === ts.SyntaxKind.ParenthesizedType) {
+    let typeNode = type as ts.ParenthesizedTypeNode;
+    return getParameterType(typeNode.type, unionTypeCollector, mode);
+  }
+
   if (type.kind == ts.SyntaxKind.ArrayType) {
     let arrayType = type as unknown as ts.ArrayTypeNode;
     return {

--- a/bridge/scripts/code_generator/src/idl/generateHeader.ts
+++ b/bridge/scripts/code_generator/src/idl/generateHeader.ts
@@ -4,7 +4,13 @@ import {IDLBlob} from "./IDLBlob";
 import {getClassName} from "./utils";
 import fs from 'fs';
 import path from 'path';
-import {generateCoreTypeValue, generateRawTypeValue, isPointerType, isTypeHaveNull} from "./generateSource";
+import {
+  generateCoreTypeValue,
+  generateRawTypeValue,
+  getPointerType,
+  isPointerType,
+  isTypeHaveNull
+} from "./generateSource";
 import {GenerateOptions} from "./generator";
 import {ParameterType} from "./analyzer";
 import {
@@ -113,7 +119,8 @@ export function generateUnionTypeHeader(unionType: ParameterType): string {
     generateUnionMemberType,
     generateUnionMemberName,
     isTypeHaveNull,
-    isPointerType
+    isPointerType,
+    getPointerType,
   }).split('\n').filter(str => {
     return str.trim().length > 0;
   }).join('\n');

--- a/bridge/scripts/code_generator/src/idl/generateSource.ts
+++ b/bridge/scripts/code_generator/src/idl/generateSource.ts
@@ -149,7 +149,7 @@ export function isPointerType(type: ParameterType): boolean {
   return false;
 }
 
-function getPointerType(type: ParameterType): string {
+export function getPointerType(type: ParameterType): string {
   if (typeof type.value === 'string') {
     return type.value;
   }
@@ -400,7 +400,7 @@ ${returnValueAssignment} self->${generateCallMethodName(declaration.name)}(${min
     call = `${returnValueAssignment} ${getClassName(blob)}::${generateCallMethodName(declaration.name)}(context, ${requiredArguments.join(',')});`;
   }
 
-  let minimalRequiredCall = declaration.args.length == 0 ? call : `if (argc <= ${minimalRequiredArgc}) {
+  let minimalRequiredCall = (declaration.args.length == 0 || (declaration.args[0].isDotDotDot)) ? call : `if (argc <= ${minimalRequiredArgc}) {
   ${call}
   break;
 }`;

--- a/bridge/scripts/code_generator/src/idl/generateUnionTypes.ts
+++ b/bridge/scripts/code_generator/src/idl/generateUnionTypes.ts
@@ -70,7 +70,7 @@ export function generateUnionMemberName(unionType: ParameterType) {
   if (typeof v == 'number') {
     return FunctionArgumentType[v];
   } else if (unionType.isArray && typeof v == 'object' && !Array.isArray(v)) {
-    return 'sequence' + FunctionArgumentType[v.value as number];
+    return 'sequence' + typeof v.value === 'number' ? FunctionArgumentType[v.value as number] : v.value;
   } else if (typeof v == 'string') {
     return v;
   }

--- a/bridge/scripts/code_generator/templates/idl_templates/union.cc.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/union.cc.tpl
@@ -24,9 +24,16 @@ std::shared_ptr<<%= generateUnionTypeClassName(unionType) %>> <%= generateUnionT
       return std::make_shared<<%= generateUnionTypeClassName(unionType) %>>(v);
     }
     <% } %>
-
   <% }) %>
+<% if(isTypeHaveString(unionType)) { %>
+  auto&& v = Converter<IDLDOMString>::FromValue(ctx, value, exception_state);
+  if (UNLIKELY(exception_state.HasException())) {
+    return nullptr;
+  }
+  return std::make_shared<<%= generateUnionTypeClassName(unionType) %>>(v);
+<% } else { %>
   return nullptr;
+<% } %>
 }
 
 <% _.forEach(unionType, (type) => { %>

--- a/bridge/scripts/code_generator/templates/idl_templates/union.cc.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/union.cc.tpl
@@ -3,6 +3,9 @@
 * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
 
+#include "core/html/html_image_element.h"
+#include "core/html/canvas/html_canvas_element.h"
+#include "core/html/canvas/canvas_gradient.h"
 #include "<%= generateUnionTypeFileName(unionType) %>.h"
 #include "bindings/qjs/converter_impl.h"
 #include "core/html/html_image_element.h"

--- a/bridge/scripts/code_generator/templates/idl_templates/union.h.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/union.h.tpl
@@ -11,11 +11,14 @@
 #include "bindings/qjs/union_base.h"
 #include "bindings/qjs/atomic_string.h"
 #include "bindings/qjs/cppgc/member.h"
-#include "core/html/html_image_element.h"
-#include "core/html/canvas/html_canvas_element.h"
-#include "core/html/canvas/canvas_gradient.h"
 
 namespace webf {
+
+<% _.forEach(unionType, (type, index) => { %>
+  <% if (isPointerType(type)) { %>
+    class <%= getPointerType(type) %>;
+  <% } %>
+<% }); %>
 
 class <%= generateUnionTypeClassName(unionType) %> final : public UnionBase {
  public:

--- a/integration_tests/runtime/global.ts
+++ b/integration_tests/runtime/global.ts
@@ -44,6 +44,7 @@ function test(fn, title) {
 function ftest(fn, title) {
   fit(title, fn);
 }
+
 function xtest(fn, title) {
   xit(title, fn)
 }

--- a/integration_tests/specs/dom/nodes/child-node.ts
+++ b/integration_tests/specs/dom/nodes/child-node.ts
@@ -1,0 +1,317 @@
+describe('ChildNode before', function () {
+  function test_before(child, nodeName, innerHTML) {
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.before();
+      assert_equals(parent.innerHTML, innerHTML);
+    }, nodeName + '.before() without any argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.before(null);
+      var expected = 'null' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with null as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.before(undefined);
+      var expected = 'undefined' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with undefined as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.before('');
+      assert_equals(parent.firstChild.data, '');
+    }, nodeName + '.before() with the empty string as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.before('text');
+      var expected = 'text' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with only text as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      parent.appendChild(child);
+      child.before(x);
+      var expected = '<x></x>' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with only one element as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      parent.appendChild(child);
+      child.before(x, 'text');
+      var expected = '<x></x>text' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with one element and text as arguments.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.before('text', child);
+      var expected = 'text' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with context object itself as the argument.');
+
+    test(function() {
+      var parent = document.createElement('div')
+      var x = document.createElement('x');
+      parent.appendChild(child);
+      parent.appendChild(x);
+      child.before(x, child);
+      var expected = '<x></x>' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with context object itself and node as the arguments, switching positions.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      var z = document.createElement('z');
+      parent.appendChild(y);
+      parent.appendChild(child);
+      parent.appendChild(x);
+      child.before(x, y, z);
+      var expected = '<x></x><y></y><z></z>' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with all siblings of child as arguments.');
+
+    test(function() {
+      var parent = document.createElement('div')
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      var z = document.createElement('z');
+      parent.appendChild(x);
+      parent.appendChild(y);
+      parent.appendChild(z);
+      parent.appendChild(child);
+      child.before(y, z);
+      var expected = '<x></x><y></y><z></z>' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with some siblings of child as arguments; no changes in tree; viable sibling is first child.');
+
+    test(function() {
+      var parent = document.createElement('div')
+      var v = document.createElement('v');
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      var z = document.createElement('z');
+      parent.appendChild(v);
+      parent.appendChild(x);
+      parent.appendChild(y);
+      parent.appendChild(z);
+      parent.appendChild(child);
+      child.before(y, z);
+      var expected = '<v></v><x></x><y></y><z></z>' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with some siblings of child as arguments; no changes in tree.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      parent.appendChild(x);
+      parent.appendChild(y);
+      parent.appendChild(child);
+      child.before(y, x);
+      var expected = '<y></y><x></x>' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() when pre-insert behaves like prepend.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      parent.appendChild(x);
+      parent.appendChild(document.createTextNode('1'));
+      var y = document.createElement('y');
+      parent.appendChild(y);
+      parent.appendChild(child);
+      child.before(x, '2');
+      var expected = '1<y></y><x></x>2' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with one sibling of child and text as arguments.');
+
+    test(function() {
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      x.before(y);
+      assert_equals(x.previousSibling, null);
+    }, nodeName + '.before() on a child without any parent.');
+  }
+
+  test_before(document.createComment('test'), 'Comment', '<!--test-->');
+  test_before(document.createElement('test'), 'Element', '<test></test>');
+  test_before(document.createTextNode('test'), 'Text', 'test');
+
+});
+
+describe('ChildNode after', function() {
+
+  function test_after(child, nodeName, innerHTML) {
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.after();
+      assert_equals(parent.innerHTML, innerHTML);
+    }, nodeName + '.after() without any argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.after(null);
+      var expected = innerHTML + 'null';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with null as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.after(undefined);
+      var expected = innerHTML + 'undefined';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with undefined as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.after('');
+      assert_equals(parent.lastChild.data, '');
+    }, nodeName + '.after() with the empty string as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.after('text');
+      var expected = innerHTML + 'text';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with only text as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      parent.appendChild(child);
+      child.after(x);
+      var expected = innerHTML + '<x></x>';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with only one element as an argument.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      parent.appendChild(child);
+      child.after(x, 'text');
+      var expected = innerHTML + '<x></x>text';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with one element and text as arguments.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      parent.appendChild(child);
+      child.after('text', child);
+      var expected = 'text' + innerHTML;
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with context object itself as the argument.');
+
+    test(function() {
+      var parent = document.createElement('div')
+      var x = document.createElement('x');
+      parent.appendChild(x);
+      parent.appendChild(child);
+      child.after(child, x);
+      var expected = innerHTML + '<x></x>';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with context object itself and node as the arguments, switching positions.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      var z = document.createElement('z');
+      parent.appendChild(y);
+      parent.appendChild(child);
+      parent.appendChild(x);
+      child.after(x, y, z);
+      var expected = innerHTML + '<x></x><y></y><z></z>';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with all siblings of child as arguments.');
+
+    test(function() {
+      var parent = document.createElement('div')
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      var z = document.createElement('z');
+      parent.appendChild(child);
+      parent.appendChild(x);
+      parent.appendChild(y);
+      parent.appendChild(z);
+      child.after(x, y);
+      var expected = innerHTML + '<x></x><y></y><z></z>';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with some siblings of child as arguments; no changes in tree; viable sibling is first child.');
+
+    test(function() {
+      var parent = document.createElement('div')
+      var v = document.createElement('v');
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      var z = document.createElement('z');
+      parent.appendChild(child);
+      parent.appendChild(v);
+      parent.appendChild(x);
+      parent.appendChild(y);
+      parent.appendChild(z);
+      child.after(v, x);
+      var expected = innerHTML + '<v></v><x></x><y></y><z></z>';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with some siblings of child as arguments; no changes in tree.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      parent.appendChild(child);
+      parent.appendChild(x);
+      parent.appendChild(y);
+      child.after(y, x);
+      var expected = innerHTML + '<y></y><x></x>';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() when pre-insert behaves like append.');
+
+    test(function() {
+      var parent = document.createElement('div');
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      parent.appendChild(child);
+      parent.appendChild(x);
+      parent.appendChild(document.createTextNode('1'));
+      parent.appendChild(y);
+      child.after(x, '2');
+      var expected = innerHTML + '<x></x>21<y></y>';
+      assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with one sibling of child and text as arguments.');
+
+    test(function() {
+      var x = document.createElement('x');
+      var y = document.createElement('y');
+      x.after(y);
+      assert_equals(x.nextSibling, null);
+    }, nodeName + '.after() on a child without any parent.');
+  }
+
+  test_after(document.createComment('test'), 'Comment', '<!--test-->');
+  test_after(document.createElement('test'), 'Element', '<test></test>');
+  test_after(document.createTextNode('test'), 'Text', 'test');
+});

--- a/integration_tests/specs/dom/nodes/parent-node.ts
+++ b/integration_tests/specs/dom/nodes/parent-node.ts
@@ -1,0 +1,116 @@
+describe('ParentNode append', function () {
+  function test_append(node, nodeName) {
+    test(function() {
+      const parent = node.cloneNode();
+      parent.append();
+      expect(parent.childNodes.length).toBe(0);
+    }, nodeName + '.append() without any argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      parent.append(null);
+      assert_equals(parent.childNodes[0].textContent, 'null');
+    }, nodeName + '.append() with null as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      parent.append(undefined);
+      assert_equals(parent.childNodes[0].textContent, 'undefined');
+    }, nodeName + '.append() with undefined as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      parent.append('text');
+      assert_equals(parent.childNodes[0].textContent, 'text');
+    }, nodeName + '.append() with only text as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      const x = document.createElement('x');
+      parent.append(x);
+      assert_equals(parent.childNodes[0], x);
+    }, nodeName + '.append() with only one element as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      const child = document.createElement('test');
+      parent.appendChild(child);
+      parent.append(null);
+      assert_equals(parent.childNodes[0], child);
+      assert_equals(parent.childNodes[1].textContent, 'null');
+    }, nodeName + '.append() with null as an argument, on a parent having a child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      const x = document.createElement('x');
+      const child = document.createElement('test');
+      parent.appendChild(child);
+      parent.append(x, 'text');
+      assert_equals(parent.childNodes[0], child);
+      assert_equals(parent.childNodes[1], x);
+      assert_equals(parent.childNodes[2].textContent, 'text');
+    }, nodeName + '.append() with one element and text as argument, on a parent having a child.');
+  }
+
+  test_append(document.createElement('div'), 'Element');
+  test_append(document.createDocumentFragment(), 'DocumentFragment');
+});
+
+describe('ParentNode prepend', function () {
+
+  function test_prepend(node, nodeName) {
+    test(function() {
+      const parent = node.cloneNode();
+      parent.prepend();
+      assert_array_equals(parent.childNodes.length, 0);
+    }, nodeName + '.prepend() without any argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      parent.prepend(null);
+      assert_equals(parent.childNodes[0].textContent, 'null');
+    }, nodeName + '.prepend() with null as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      parent.prepend(undefined);
+      assert_equals(parent.childNodes[0].textContent, 'undefined');
+    }, nodeName + '.prepend() with undefined as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      parent.prepend('text');
+      assert_equals(parent.childNodes[0].textContent, 'text');
+    }, nodeName + '.prepend() with only text as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      const x = document.createElement('x');
+      parent.prepend(x);
+      assert_array_equals(parent.childNodes[0], x);
+    }, nodeName + '.prepend() with only one element as an argument, on a parent having no child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      const child = document.createElement('test');
+      parent.appendChild(child);
+      parent.prepend(null);
+      assert_equals(parent.childNodes[0].textContent, 'null');
+      assert_equals(parent.childNodes[1], child);
+    }, nodeName + '.prepend() with null as an argument, on a parent having a child.');
+
+    test(function() {
+      const parent = node.cloneNode();
+      const x = document.createElement('x');
+      const child = document.createElement('test');
+      parent.appendChild(child);
+      parent.prepend(x, 'text');
+      assert_equals(parent.childNodes[0], x);
+      assert_equals(parent.childNodes[1].textContent, 'text');
+      assert_equals(parent.childNodes[2], child);
+    }, nodeName + '.prepend() with one element and text as argument, on a parent having a child.');
+  }
+
+  test_prepend(document.createElement('div'), 'Element');
+  test_prepend(document.createDocumentFragment(), 'DocumentFragment');
+});

--- a/scripts/generate_binding_code.js
+++ b/scripts/generate_binding_code.js
@@ -1,0 +1,18 @@
+/**
+ * Only build libkraken.dylib for macOS
+ */
+const { series } = require('gulp');
+const chalk = require('chalk');
+
+require('./tasks');
+
+// Run tasks
+series(
+  'generate-bindings-code',
+)((err) => {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(chalk.green('Success.'));
+  }
+});

--- a/webf/lib/src/foundation/cookie_jar/file_storage.dart
+++ b/webf/lib/src/foundation/cookie_jar/file_storage.dart
@@ -108,6 +108,7 @@ class FileStorage implements Storage {
 
   @override
   void writeSync(String key, String value) {
+    if (key.isEmpty) return;
     _makeCookieDirSync();
     final file = File('$_curDir$key');
     if (writePreHandler != null) {


### PR DESCRIPTION
1. Add `append()` and `prepend()` support for [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element/append), [Document](https://developer.mozilla.org/en-US/docs/Web/API/Document/append) and [DocumentElement](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment/append).
2. Add `before()` and `after()` support for [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element/before) and [CharaterData](https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/before). 