### PR TITLE
Chore: remove legacy codes.

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -485,7 +485,6 @@ if ($ENV{WEBF_JS_ENGINE} MATCHES "quickjs")
     out/html_names.cc
     out/script_type_names.cc
     out/defined_properties.cc
-    out/defined_properties_initializer.cc
     out/element_attribute_names.cc
     out/element_namespace_uris.cc
 

--- a/bridge/bindings/qjs/cppgc/mutation_scope.cc
+++ b/bridge/bindings/qjs/cppgc/mutation_scope.cc
@@ -9,7 +9,8 @@
 
 namespace webf {
 
-MemberMutationScope::MemberMutationScope(ExecutingContext* context) : context_(context), runtime_(context->GetScriptState()->runtime()) {
+MemberMutationScope::MemberMutationScope(ExecutingContext* context)
+    : context_(context), runtime_(context->GetScriptState()->runtime()) {
   context->SetMutationScope(*this);
 }
 

--- a/bridge/bindings/qjs/cppgc/mutation_scope.cc
+++ b/bridge/bindings/qjs/cppgc/mutation_scope.cc
@@ -9,7 +9,7 @@
 
 namespace webf {
 
-MemberMutationScope::MemberMutationScope(ExecutingContext* context) : context_(context) {
+MemberMutationScope::MemberMutationScope(ExecutingContext* context) : context_(context), runtime_(context->GetScriptState()->runtime()) {
   context->SetMutationScope(*this);
 }
 
@@ -35,10 +35,9 @@ void MemberMutationScope::RecordFree(ScriptWrappable* wrappable) {
 }
 
 void MemberMutationScope::ApplyRecord() {
-  JSRuntime* runtime = context_->GetScriptState()->runtime();
   for (auto& entry : mutation_records_) {
     for (int i = 0; i < -entry.second; i++) {
-      JS_FreeValueRT(runtime, entry.first->ToQuickJSUnsafe());
+      JS_FreeValueRT(runtime_, entry.first->ToQuickJSUnsafe());
     }
   }
 }

--- a/bridge/bindings/qjs/cppgc/mutation_scope.h
+++ b/bridge/bindings/qjs/cppgc/mutation_scope.h
@@ -36,6 +36,7 @@ class MemberMutationScope {
 
   MemberMutationScope* parent_scope_{nullptr};
   ExecutingContext* context_;
+  JSRuntime* runtime_{nullptr};
   std::unordered_map<ScriptWrappable*, int> mutation_records_;
 };
 

--- a/bridge/core/dom/character_data.cc
+++ b/bridge/core/dom/character_data.cc
@@ -31,10 +31,6 @@ void CharacterData::setNodeValue(const AtomicString& value, ExceptionState& exce
   setData(!value.IsEmpty() ? value : built_in_string::kempty_string, exception_state);
 }
 
-bool CharacterData::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSCharacterData::IsAttributeDefinedInternal(key) || Node::IsAttributeDefinedInternal(key);
-}
-
 CharacterData::CharacterData(TreeScope& tree_scope, const AtomicString& text, Node::ConstructionType type)
     : Node(tree_scope.GetDocument().GetExecutingContext(), &tree_scope, type), data_(text) {
   assert(type == kCreateOther || type == kCreateText);

--- a/bridge/core/dom/character_data.h
+++ b/bridge/core/dom/character_data.h
@@ -23,9 +23,6 @@ class CharacterData : public Node {
   AtomicString nodeValue() const override;
   bool IsCharacterDataNode() const override;
   void setNodeValue(const AtomicString&, ExceptionState&) override;
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
  protected:
   CharacterData(TreeScope& tree_scope, const AtomicString& text, ConstructionType type);
 

--- a/bridge/core/dom/character_data.h
+++ b/bridge/core/dom/character_data.h
@@ -23,6 +23,7 @@ class CharacterData : public Node {
   AtomicString nodeValue() const override;
   bool IsCharacterDataNode() const override;
   void setNodeValue(const AtomicString&, ExceptionState&) override;
+
  protected:
   CharacterData(TreeScope& tree_scope, const AtomicString& text, ConstructionType type);
 

--- a/bridge/core/dom/document.cc
+++ b/bridge/core/dom/document.cc
@@ -219,10 +219,10 @@ std::vector<Element*> Document::getElementsByName(const AtomicString& name, Exce
 
 Element* Document::elementFromPoint(double x, double y, ExceptionState& exception_state) {
   GetExecutingContext()->FlushUICommand();
-    const NativeValue args[] = {
-        NativeValueConverter<NativeTypeDouble>::ToNativeValue(x),
-        NativeValueConverter<NativeTypeDouble>::ToNativeValue(y),
-    };
+  const NativeValue args[] = {
+      NativeValueConverter<NativeTypeDouble>::ToNativeValue(x),
+      NativeValueConverter<NativeTypeDouble>::ToNativeValue(y),
+  };
   NativeValue result = InvokeBindingMethod(binding_call_methods::kelementFromPoint, 2, args, exception_state);
   if (exception_state.HasException()) {
     return nullptr;

--- a/bridge/core/dom/document.cc
+++ b/bridge/core/dom/document.cc
@@ -395,10 +395,6 @@ std::shared_ptr<EventListener> Document::GetWindowAttributeEventListener(const A
   return window->GetAttributeEventListener(event_type);
 }
 
-bool Document::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSDocument::IsAttributeDefinedInternal(key) || Node::IsAttributeDefinedInternal(key);
-}
-
 void Document::Trace(GCVisitor* visitor) const {
   script_animation_controller_.Trace(visitor);
   ContainerNode::Trace(visitor);

--- a/bridge/core/dom/document.h
+++ b/bridge/core/dom/document.h
@@ -117,8 +117,6 @@ class Document : public ContainerNode, public TreeScope {
                                        ExceptionState& exception_state);
   std::shared_ptr<EventListener> GetWindowAttributeEventListener(const AtomicString& event_type);
 
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
   void Trace(GCVisitor* visitor) const override;
 
  private:

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -307,10 +307,6 @@ bool Element::IsWidgetElement() const {
   return false;
 }
 
-bool Element::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSElement::IsAttributeDefinedInternal(key) || Node::IsAttributeDefinedInternal(key);
-}
-
 void Element::Trace(GCVisitor* visitor) const {
   visitor->Trace(attributes_);
   visitor->Trace(cssom_wrapper_);

--- a/bridge/core/dom/element.h
+++ b/bridge/core/dom/element.h
@@ -100,7 +100,6 @@ class Element : public ContainerNode {
   virtual void CloneNonAttributePropertiesFrom(const Element&, CloneChildrenFlag) {}
   virtual bool IsWidgetElement() const;
 
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
   void Trace(GCVisitor* visitor) const override;
 
  protected:

--- a/bridge/core/dom/events/event_target.cc
+++ b/bridge/core/dom/events/event_target.cc
@@ -188,10 +188,6 @@ bool EventTarget::IsEventTarget() const {
   return true;
 }
 
-bool EventTarget::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSEventTarget::IsAttributeDefinedInternal(key);
-}
-
 void EventTarget::Trace(GCVisitor* visitor) const {
   ScriptWrappable::Trace(visitor);
   BindingObject::Trace(visitor);

--- a/bridge/core/dom/events/event_target.h
+++ b/bridge/core/dom/events/event_target.h
@@ -130,9 +130,6 @@ class EventTarget : public BindingObject {
   virtual bool IsNode() const { return false; }
   bool IsEventTarget() const override;
 
-  // Check the attribute is defined in native.
-  virtual bool IsAttributeDefinedInternal(const AtomicString& key) const;
-
   NativeValue HandleCallFromDartSide(const AtomicString& method, int32_t argc, const NativeValue* argv) override;
 
   void Trace(GCVisitor* visitor) const override;

--- a/bridge/core/dom/events/registered_eventListener.cc
+++ b/bridge/core/dom/events/registered_eventListener.cc
@@ -31,6 +31,7 @@ bool RegisteredEventListener::Matches(const std::shared_ptr<EventListener>& list
   // Equality is soley based on the listener and useCapture flags.
   assert(callback_);
   assert(listener);
+  assert(options != nullptr);
   return callback_->Matches(*listener) &&
          static_cast<bool>(use_capture_) == (options->hasCapture() && options->capture());
 }

--- a/bridge/core/dom/node.cc
+++ b/bridge/core/dom/node.cc
@@ -116,10 +116,6 @@ NodeData& Node::EnsureNodeData() {
   return CreateNodeData();
 }
 
-bool Node::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSNode::IsAttributeDefinedInternal(key) || EventTarget::IsAttributeDefinedInternal(key);
-}
-
 Node& Node::TreeRoot() const {
   const Node* node = this;
   while (node->parentNode())

--- a/bridge/core/dom/node.h
+++ b/bridge/core/dom/node.h
@@ -240,8 +240,6 @@ class Node : public EventTarget {
   [[nodiscard]] NodeData* Data() const { return node_data_.get(); }
   NodeData& EnsureNodeData();
 
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
   void Trace(GCVisitor*) const override;
 
  private:

--- a/bridge/core/html/canvas/html_canvas_element.cc
+++ b/bridge/core/html/canvas/html_canvas_element.cc
@@ -37,8 +37,4 @@ void HTMLCanvasElement::Trace(GCVisitor* visitor) const {
   HTMLElement::Trace(visitor);
 }
 
-bool HTMLCanvasElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLCanvasElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/canvas/html_canvas_element.h
+++ b/bridge/core/html/canvas/html_canvas_element.h
@@ -19,8 +19,6 @@ class HTMLCanvasElement : public HTMLElement {
 
   CanvasRenderingContext* getContext(const AtomicString& type, ExceptionState& exception_state);
 
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
   void Trace(GCVisitor* visitor) const override;
 
   std::vector<Member<CanvasRenderingContext>> running_context_2ds_;

--- a/bridge/core/html/custom/widget_element.cc
+++ b/bridge/core/html/custom/widget_element.cc
@@ -140,10 +140,6 @@ void WidgetElement::CloneNonAttributePropertiesFrom(const Element& other, CloneC
   }
 }
 
-bool WidgetElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return true;
-}
-
 NativeValue WidgetElement::HandleSyncPropertiesAndMethodsFromDart(int32_t argc, const NativeValue* argv) {
   assert(argc == 3);
   AtomicString key = tagName();

--- a/bridge/core/html/custom/widget_element.h
+++ b/bridge/core/html/custom/widget_element.h
@@ -38,6 +38,7 @@ class WidgetElement : public HTMLElement {
   void CloneNonAttributePropertiesFrom(const Element&, CloneChildrenFlag) override;
 
   void Trace(GCVisitor* visitor) const override;
+
  private:
   ScriptValue CreateSyncMethodFunc(const AtomicString& method_name);
   ScriptValue CreateAsyncMethodFunc(const AtomicString& method_name);

--- a/bridge/core/html/custom/widget_element.h
+++ b/bridge/core/html/custom/widget_element.h
@@ -38,8 +38,6 @@ class WidgetElement : public HTMLElement {
   void CloneNonAttributePropertiesFrom(const Element&, CloneChildrenFlag) override;
 
   void Trace(GCVisitor* visitor) const override;
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
  private:
   ScriptValue CreateSyncMethodFunc(const AtomicString& method_name);
   ScriptValue CreateAsyncMethodFunc(const AtomicString& method_name);

--- a/bridge/core/html/forms/html_button_element.cc
+++ b/bridge/core/html/forms/html_button_element.cc
@@ -8,8 +8,4 @@
 
 namespace webf {
 
-bool HTMLButtonElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLButtonElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/forms/html_button_element.cc
+++ b/bridge/core/html/forms/html_button_element.cc
@@ -6,6 +6,4 @@
 #include "html_button_element.h"
 #include "qjs_html_button_element.h"
 
-namespace webf {
-
-}  // namespace webf
+namespace webf {}  // namespace webf

--- a/bridge/core/html/forms/html_button_element.h
+++ b/bridge/core/html/forms/html_button_element.h
@@ -14,9 +14,6 @@ class HTMLButtonElement : public HTMLElement {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_anchor_element.cc
+++ b/bridge/core/html/html_anchor_element.cc
@@ -10,8 +10,4 @@ namespace webf {
 
 HTMLAnchorElement::HTMLAnchorElement(Document& document) : HTMLElement(html_names::ka, &document) {}
 
-bool HTMLAnchorElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLAnchorElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_anchor_element.h
+++ b/bridge/core/html/html_anchor_element.h
@@ -14,9 +14,6 @@ class HTMLAnchorElement : public HTMLElement {
 
  public:
   explicit HTMLAnchorElement(Document& document);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
  private:
 };
 

--- a/bridge/core/html/html_anchor_element.h
+++ b/bridge/core/html/html_anchor_element.h
@@ -14,6 +14,7 @@ class HTMLAnchorElement : public HTMLElement {
 
  public:
   explicit HTMLAnchorElement(Document& document);
+
  private:
 };
 

--- a/bridge/core/html/html_body_element.cc
+++ b/bridge/core/html/html_body_element.cc
@@ -10,8 +10,4 @@ namespace webf {
 
 HTMLBodyElement::HTMLBodyElement(Document& document) : HTMLElement(html_names::kbody, &document) {}
 
-bool HTMLBodyElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLBodyElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_body_element.h
+++ b/bridge/core/html/html_body_element.h
@@ -18,8 +18,6 @@ class HTMLBodyElement : public HTMLElement {
   using ImplType = HTMLBodyElement*;
   explicit HTMLBodyElement(Document&);
 
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
   DEFINE_WINDOW_ATTRIBUTE_EVENT_LISTENER(blur, kblur);
   DEFINE_WINDOW_ATTRIBUTE_EVENT_LISTENER(error, kerror);
   DEFINE_WINDOW_ATTRIBUTE_EVENT_LISTENER(focus, kfocus);

--- a/bridge/core/html/html_div_element.cc
+++ b/bridge/core/html/html_div_element.cc
@@ -11,8 +11,4 @@ namespace webf {
 
 HTMLDivElement::HTMLDivElement(Document& document) : HTMLElement(html_names::kdiv, &document) {}
 
-bool HTMLDivElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLDivElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_div_element.h
+++ b/bridge/core/html/html_div_element.h
@@ -16,10 +16,6 @@ class HTMLDivElement : public HTMLElement {
  public:
   using ImplType = HTMLDivElement*;
   explicit HTMLDivElement(Document&);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_element.cc
+++ b/bridge/core/html/html_element.cc
@@ -5,15 +5,10 @@
 
 #include "html_element.h"
 #include "element_namespace_uris.h"
-#include "qjs_html_element.h"
 
 namespace webf {
 
 HTMLElement::HTMLElement(const AtomicString& tag_name, Document* document, ConstructionType type)
     : Element(element_namespace_uris::khtml, tag_name, AtomicString::Null(), document, type) {}
-
-bool HTMLElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLElement::IsAttributeDefinedInternal(key) || Element::IsAttributeDefinedInternal(key);
-}
 
 }  // namespace webf

--- a/bridge/core/html/html_element.h
+++ b/bridge/core/html/html_element.h
@@ -17,10 +17,6 @@ class HTMLElement : public Element {
  public:
   using ImplType = HTMLElement*;
   HTMLElement(const AtomicString& tag_name, Document* document, ConstructionType = kCreateHTMLElement);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 template <typename T>

--- a/bridge/core/html/html_head_element.cc
+++ b/bridge/core/html/html_head_element.cc
@@ -10,8 +10,4 @@ namespace webf {
 
 HTMLHeadElement::HTMLHeadElement(Document& document) : HTMLElement(html_names::khead, &document) {}
 
-bool HTMLHeadElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLHeadElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_head_element.h
+++ b/bridge/core/html/html_head_element.h
@@ -15,10 +15,6 @@ class HTMLHeadElement : public HTMLElement {
  public:
   using ImplType = HTMLHeadElement*;
   explicit HTMLHeadElement(Document&);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_html_element.cc
+++ b/bridge/core/html/html_html_element.cc
@@ -9,9 +9,4 @@
 namespace webf {
 
 HTMLHtmlElement::HTMLHtmlElement(Document& document) : HTMLElement(html_names::khtml, &document) {}
-
-bool HTMLHtmlElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLHtmlElement::IsAttributeDefinedInternal(key) || HTMLHtmlElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_html_element.h
+++ b/bridge/core/html/html_html_element.h
@@ -15,10 +15,6 @@ class HTMLHtmlElement : public HTMLElement {
  public:
   using ImplType = HTMLHtmlElement*;
   explicit HTMLHtmlElement(Document&);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_iframe_element.cc
+++ b/bridge/core/html/html_iframe_element.cc
@@ -10,8 +10,4 @@ namespace webf {
 
 HTMLIFrameElement::HTMLIFrameElement(Document& document) : HTMLElement(html_names::khtml, &document) {}
 
-bool HTMLIFrameElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLIFrameElement::IsAttributeDefinedInternal(key) || HTMLIFrameElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_iframe_element.h
+++ b/bridge/core/html/html_iframe_element.h
@@ -15,6 +15,7 @@ class HTMLIFrameElement : public HTMLElement {
  public:
   using ImplType = HTMLIFrameElement*;
   explicit HTMLIFrameElement(Document&);
+
  private:
 };
 

--- a/bridge/core/html/html_iframe_element.h
+++ b/bridge/core/html/html_iframe_element.h
@@ -15,9 +15,6 @@ class HTMLIFrameElement : public HTMLElement {
  public:
   using ImplType = HTMLIFrameElement*;
   explicit HTMLIFrameElement(Document&);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
  private:
 };
 

--- a/bridge/core/html/html_image_element.cc
+++ b/bridge/core/html/html_image_element.cc
@@ -14,10 +14,6 @@ namespace webf {
 
 HTMLImageElement::HTMLImageElement(Document& document) : HTMLElement(html_names::kimg, &document) {}
 
-bool HTMLImageElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLImageElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 ScriptPromise HTMLImageElement::decode(ExceptionState& exception_state) const {
   exception_state.ThrowException(ctx(), ErrorType::InternalError, "Not implemented.");
   // @TODO not implemented.

--- a/bridge/core/html/html_image_element.h
+++ b/bridge/core/html/html_image_element.h
@@ -15,9 +15,6 @@ class HTMLImageElement : public HTMLElement {
  public:
   using ImplType = HTMLImageElement*;
   explicit HTMLImageElement(Document& document);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
   AtomicString src() const;
   void setSrc(const AtomicString& value, ExceptionState& exception_state);
 

--- a/bridge/core/html/html_link_element.cc
+++ b/bridge/core/html/html_link_element.cc
@@ -11,8 +11,4 @@ namespace webf {
 
 HTMLLinkElement::HTMLLinkElement(Document& document) : HTMLElement(html_names::klink, &document) {}
 
-bool HTMLLinkElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLLinkElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_link_element.h
+++ b/bridge/core/html/html_link_element.h
@@ -15,10 +15,6 @@ class HTMLLinkElement : public HTMLElement {
 
  public:
   explicit HTMLLinkElement(Document& document);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_script_element.cc
+++ b/bridge/core/html/html_script_element.cc
@@ -19,8 +19,4 @@ bool HTMLScriptElement::supports(const AtomicString& type, ExceptionState& excep
   return false;
 }
 
-bool HTMLScriptElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLScriptElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_script_element.h
+++ b/bridge/core/html/html_script_element.h
@@ -16,10 +16,6 @@ class HTMLScriptElement : public HTMLElement {
   static bool supports(const AtomicString& type, ExceptionState& exception_state);
 
   explicit HTMLScriptElement(Document& document);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_template_element.cc
+++ b/bridge/core/html/html_template_element.cc
@@ -26,8 +26,4 @@ void HTMLTemplateElement::Trace(webf::GCVisitor* visitor) const {
   visitor->Trace(content_);
 }
 
-bool HTMLTemplateElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLTemplateElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_template_element.h
+++ b/bridge/core/html/html_template_element.h
@@ -19,8 +19,6 @@ class HTMLTemplateElement : public HTMLElement {
 
   DocumentFragment* content() const;
 
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
   void Trace(webf::GCVisitor* visitor) const override;
 
  private:

--- a/bridge/core/html/html_unknown_element.cc
+++ b/bridge/core/html/html_unknown_element.cc
@@ -10,8 +10,4 @@ namespace webf {
 HTMLUnknownElement::HTMLUnknownElement(const AtomicString& tag_name, Document* document)
     : HTMLElement(tag_name, document) {}
 
-bool HTMLUnknownElement::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSHTMLUnknownElement::IsAttributeDefinedInternal(key) || HTMLElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/html_unknown_element.h
+++ b/bridge/core/html/html_unknown_element.h
@@ -15,9 +15,6 @@ class HTMLUnknownElement : public HTMLElement {
  public:
   explicit HTMLUnknownElement(const AtomicString&, Document* document);
 
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
- private:
 };
 
 }  // namespace webf

--- a/bridge/core/html/html_unknown_element.h
+++ b/bridge/core/html/html_unknown_element.h
@@ -14,7 +14,6 @@ class HTMLUnknownElement : public HTMLElement {
 
  public:
   explicit HTMLUnknownElement(const AtomicString&, Document* document);
-
 };
 
 }  // namespace webf

--- a/bridge/core/html/image.cc
+++ b/bridge/core/html/image.cc
@@ -13,8 +13,4 @@ Image* Image::Create(ExecutingContext* context, ExceptionState& exception_state)
 
 Image::Image(ExecutingContext* context, ExceptionState& exception_state) : HTMLImageElement(*context->document()) {}
 
-bool Image::IsAttributeDefinedInternal(const AtomicString& key) const {
-  return QJSImage::IsAttributeDefinedInternal(key) || HTMLImageElement::IsAttributeDefinedInternal(key);
-}
-
 }  // namespace webf

--- a/bridge/core/html/image.h
+++ b/bridge/core/html/image.h
@@ -16,6 +16,7 @@ class Image : public HTMLImageElement {
   static Image* Create(ExecutingContext* context, ExceptionState& exception_state);
 
   explicit Image(ExecutingContext* context, ExceptionState& exception_state);
+
  private:
 };
 

--- a/bridge/core/html/image.h
+++ b/bridge/core/html/image.h
@@ -16,9 +16,6 @@ class Image : public HTMLImageElement {
   static Image* Create(ExecutingContext* context, ExceptionState& exception_state);
 
   explicit Image(ExecutingContext* context, ExceptionState& exception_state);
-
-  bool IsAttributeDefinedInternal(const AtomicString& key) const override;
-
  private:
 };
 

--- a/bridge/core/script_state.cc
+++ b/bridge/core/script_state.cc
@@ -3,7 +3,6 @@
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
 #include "script_state.h"
-#include "defined_properties_initializer.h"
 #include "event_factory.h"
 #include "html_element_factory.h"
 #include "names_installer.h"

--- a/bridge/scripts/code_generator/templates/idl_templates/interface.cc.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/interface.cc.tpl
@@ -112,32 +112,6 @@ JSValue QJS<%= className %>::ConstructorCallback(JSContext* ctx, JSValue func_ob
   <% } %>
  <% } %>
 
-
-static thread_local AttributeMap* internal_properties = nullptr;
-
-void QJS<%= className %>::InitAttributeMap() {
-  internal_properties = new AttributeMap();
-
-  for(int i = 0; i < <%= object.props.length %>; i ++) {
-  <% object.props.forEach(prop => { %>
-    internal_properties->emplace(std::make_pair(defined_properties::k<%= prop.name %>, true));
-  <% }) %>
-  }
-}
-
-void QJS<%= className %>::DisposeAttributeMap() {
-  delete internal_properties;
-}
-
-AttributeMap* QJS<%= className %>::definedAttributeMap() {
-  assert(internal_properties != nullptr);
-  return internal_properties;
-}
-
-bool QJS<%= className %>::IsAttributeDefinedInternal(const AtomicString& key) {
-  return definedAttributeMap()->count(key) > 0;
-}
-
 <% _.forEach(filtedMethods, function(method, index) { %>
 
   <% if (overloadMethods[method.name] && overloadMethods[method.name].length > 1) { %>

--- a/bridge/scripts/code_generator/templates/idl_templates/interface.h.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/interface.h.tpl
@@ -33,15 +33,9 @@ Native<%= parentClassName %> native_event;
 #endif
 <% } %>
 
-using AttributeMap = std::unordered_map<AtomicString, bool, AtomicString::KeyHasher>;
-
 class QJS<%= className %> : public QJSInterfaceBridge<QJS<%= className %>, <%= className%>> {
  public:
   static void Install(ExecutingContext* context);
-  static void InitAttributeMap();
-  static void DisposeAttributeMap();
-  static AttributeMap* definedAttributeMap();
-  static bool IsAttributeDefinedInternal(const AtomicString& key);
   static WrapperTypeInfo* GetWrapperTypeInfo() {
     return const_cast<WrapperTypeInfo*>(&wrapper_type_info_);
   }


### PR DESCRIPTION
The `DefinedPropertiesInitializer` and `IsAttributeDefinedInternal()` API are legacy codes and nothing depends on them