### PR TITLE
feat: dump stacktrace when integration test crashed.

### DIFF
--- a/bridge/webf_bridge_test.cc
+++ b/bridge/webf_bridge_test.cc
@@ -5,13 +5,29 @@
 
 #include "webf_bridge_test.h"
 #include <atomic>
+#include <execinfo.h>
+#include <unistd.h>
 #include "bindings/qjs/native_string_utils.h"
 #include "logging.h"
 #include "webf_test_context.h"
 
 std::unordered_map<int, webf::WebFTestContext*> testContextPool = std::unordered_map<int, webf::WebFTestContext*>();
 
+void handler(int sig) {
+  void *array[10];
+  size_t size;
+
+  // get void*'s for all entries on the stack
+  size = backtrace(array, 10);
+
+  // print out all the frames to stderr
+  fprintf(stderr, "Error: signal %d:\n", sig);
+  backtrace_symbols_fd(array, size, STDERR_FILENO);
+  exit(1);
+}
+
 void* initTestFramework(void* page_) {
+  signal(SIGSEGV, handler);   // install handler when crashed.
   auto page = reinterpret_cast<webf::WebFPage*>(page_);
   assert(std::this_thread::get_id() == page->currentThread());
   return new webf::WebFTestContext(page->GetExecutingContext());

--- a/bridge/webf_bridge_test.cc
+++ b/bridge/webf_bridge_test.cc
@@ -4,9 +4,10 @@
  */
 
 #include "webf_bridge_test.h"
-#include <atomic>
 #include <execinfo.h>
+#include <signal.h>
 #include <unistd.h>
+#include <atomic>
 #include "bindings/qjs/native_string_utils.h"
 #include "logging.h"
 #include "webf_test_context.h"
@@ -14,7 +15,7 @@
 std::unordered_map<int, webf::WebFTestContext*> testContextPool = std::unordered_map<int, webf::WebFTestContext*>();
 
 void handler(int sig) {
-  void *array[10];
+  void* array[10];
   size_t size;
 
   // get void*'s for all entries on the stack
@@ -27,7 +28,7 @@ void handler(int sig) {
 }
 
 void* initTestFramework(void* page_) {
-  signal(SIGSEGV, handler);   // install handler when crashed.
+  signal(SIGSEGV, handler);  // install handler when crashed.
   auto page = reinterpret_cast<webf::WebFPage*>(page_);
   assert(std::this_thread::get_id() == page->currentThread());
   return new webf::WebFTestContext(page->GetExecutingContext());


### PR DESCRIPTION
When the integration crashes, it will print the following error message to help us diagnose the problems.

```
flutter: Local HTTP server started at: http://127.0.0.1:34170
Assertion failed: (p->ref_count > 0), function gc_decref_child, file gc.c, line 684.
Error: signal 6:
0   libwebf_test.dylib                  0x0000000123a4bb30 _Z7handleri + 32
1   libsystem_platform.dylib            0x00000001a4062a84 _sigtramp + 56
2   libsystem_pthread.dylib             0x00000001a4033c28 pthread_kill + 288
3   libsystem_c.dylib                   0x00000001a3f41ae8 abort + 180
4   libsystem_c.dylib                   0x00000001a3f40e44 err + 0
5   libquickjs.dylib                    0x00000001025b3940 gc_decref.cold.1 + 0
6   libquickjs.dylib                    0x00000001025452f0 gc_decref + 0
7   libquickjs.dylib                    0x0000000102544c24 JS_MarkValue + 36
8   libwebf.dylib                       0x0000000102d9380c _ZNK4webf4Node5TraceEPNS_9GCVisitorE + 40
9   libwebf.dylib                       0x0000000102da024c _ZNK4webf13ContainerNode5TraceEPNS_9GCVisitorE + 72
```