### PR TITLE
feat: add options to disable mimalloc.

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -203,9 +203,12 @@ if ($ENV{WEBF_JS_ENGINE} MATCHES "quickjs")
   endif()
 
   set(MI_OVERRIDE OFF)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/quickjs/vendor/mimalloc)
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/quickjs/vendor/mimalloc/include)
-  target_link_libraries(quickjs mimalloc-static)
+  if (NOT DEFINED USE_SYSTEM_MALLOC)
+    add_compile_definitions(ENABLE_MI_MALLOC=1)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/quickjs/vendor/mimalloc)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third_party/quickjs/vendor/mimalloc/include)
+    target_link_libraries(quickjs mimalloc-static)
+  endif()
 
   target_include_directories(quickjs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/third_party/quickjs/include)
 

--- a/bridge/test/webf_test_env.cc
+++ b/bridge/test/webf_test_env.cc
@@ -308,12 +308,12 @@ void TEST_onMatchImageSnapshot(void* callbackContext,
 }
 
 void TEST_onMatchImageSnapshotBytes(void* callback_context,
-              int32_t context_id,
-              uint8_t* image_a_bytes,
-              int32_t image_a_size,
-              uint8_t* image_b_bytes,
-              int32_t image_b_size,
-              MatchImageSnapshotCallback callback) {
+                                    int32_t context_id,
+                                    uint8_t* image_a_bytes,
+                                    int32_t image_a_size,
+                                    uint8_t* image_b_bytes,
+                                    int32_t image_b_size,
+                                    MatchImageSnapshotCallback callback) {
   callback(callback_context, contextId, 1, nullptr);
 }
 

--- a/bridge/third_party/quickjs/include/quickjs/cutils.h
+++ b/bridge/third_party/quickjs/include/quickjs/cutils.h
@@ -1,6 +1,6 @@
 /*
  * C utilities
- * 
+ *
  * Copyright (c) 2017 Fabrice Bellard
  * Copyright (c) 2018 Charlie Gordon
  *
@@ -27,7 +27,10 @@
 
 #include <stdlib.h>
 #include <inttypes.h>
+
+#if ENABLE_MI_MALLOC
 #include "mimalloc.h"
+#endif
 
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -274,13 +277,13 @@ static inline uint32_t bswap32(uint32_t v)
 
 static inline uint64_t bswap64(uint64_t v)
 {
-    return ((v & ((uint64_t)0xff << (7 * 8))) >> (7 * 8)) | 
-        ((v & ((uint64_t)0xff << (6 * 8))) >> (5 * 8)) | 
-        ((v & ((uint64_t)0xff << (5 * 8))) >> (3 * 8)) | 
-        ((v & ((uint64_t)0xff << (4 * 8))) >> (1 * 8)) | 
-        ((v & ((uint64_t)0xff << (3 * 8))) << (1 * 8)) | 
-        ((v & ((uint64_t)0xff << (2 * 8))) << (3 * 8)) | 
-        ((v & ((uint64_t)0xff << (1 * 8))) << (5 * 8)) | 
+    return ((v & ((uint64_t)0xff << (7 * 8))) >> (7 * 8)) |
+        ((v & ((uint64_t)0xff << (6 * 8))) >> (5 * 8)) |
+        ((v & ((uint64_t)0xff << (5 * 8))) >> (3 * 8)) |
+        ((v & ((uint64_t)0xff << (4 * 8))) >> (1 * 8)) |
+        ((v & ((uint64_t)0xff << (3 * 8))) << (1 * 8)) |
+        ((v & ((uint64_t)0xff << (2 * 8))) << (3 * 8)) |
+        ((v & ((uint64_t)0xff << (1 * 8))) << (5 * 8)) |
         ((v & ((uint64_t)0xff << (0 * 8))) << (7 * 8));
 }
 

--- a/bridge/third_party/quickjs/src/core/base.h
+++ b/bridge/third_party/quickjs/src/core/base.h
@@ -35,8 +35,17 @@
 #include <time.h>
 #include <fenv.h>
 #include <math.h>
+#if ENABLE_MI_MALLOC
 #include "mimalloc.h"
-
+#else
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#elif defined(__linux__)
+#include <malloc.h>
+#elif defined(__FreeBSD__)
+#include <malloc_np.h>
+#endif
+#endif
 #ifdef _MSC_VER
 
 #pragma function (ceil)

--- a/bridge/third_party/quickjs/src/core/malloc.h
+++ b/bridge/third_party/quickjs/src/core/malloc.h
@@ -29,7 +29,9 @@
 #include "quickjs/quickjs.h"
 #include "quickjs/cutils.h"
 #include "types.h"
+#if ENABLE_MI_MALLOC
 #include "mimalloc.h"
+#endif
 
 void js_trigger_gc(JSRuntime* rt, size_t size);
 no_inline int js_realloc_array(JSContext* ctx, void** parray, int elem_size, int* psize, int req_size);

--- a/bridge/third_party/quickjs/src/core/runtime.c
+++ b/bridge/third_party/quickjs/src/core/runtime.c
@@ -1219,16 +1219,16 @@ done:
   dbuf_free(&dbuf);
   JS_DefinePropertyValue(ctx, error_obj, JS_ATOM_stack, str, JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
   if (line_num != -1) {
-    JS_DefinePropertyValue(ctx, error_obj, JS_ATOM_lineNumber, JS_NewInt32(ctx, latest_line_num), 
+    JS_DefinePropertyValue(ctx, error_obj, JS_ATOM_lineNumber, JS_NewInt32(ctx, latest_line_num),
       JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
     if (column_num != -1) {
-      /** 
-       * do not add the corresponding definition 
-       * in the 'quickjs-atom.h' file, it will lead to 
+      /**
+       * do not add the corresponding definition
+       * in the 'quickjs-atom.h' file, it will lead to
        * inaccurate diff positions of the atom table
        */
       int atom = JS_NewAtom(ctx, "columnNumber");
-      JS_DefinePropertyValue(ctx, error_obj, atom, JS_NewInt32(ctx, latest_column_num), 
+      JS_DefinePropertyValue(ctx, error_obj, atom, JS_NewInt32(ctx, latest_column_num),
         JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
       JS_FreeAtom(ctx, atom);
     }
@@ -3063,7 +3063,22 @@ static const JSMallocFunctions def_malloc_funcs = {
     js_def_malloc,
     js_def_free,
     js_def_realloc,
+#if ENABLE_MI_MALLOC
     mi_usable_size,
+#else
+#if defined(__APPLE__)
+    malloc_size,
+#elif defined(_WIN32)
+    (size_t(*)(const void*))_msize,
+#elif defined(EMSCRIPTEN)
+    NULL,
+#elif defined(__linux__)
+    (size_t(*)(const void*))malloc_usable_size,
+#else
+    /* change this to `NULL,` if compilation fails */
+    malloc_usable_size,
+#endif
+#endif
 };
 
 JSRuntime* JS_NewRuntime(void) {

--- a/bridge/third_party/quickjs/src/cutils.c
+++ b/bridge/third_party/quickjs/src/cutils.c
@@ -1,6 +1,6 @@
 /*
  * C utilities
- * 
+ *
  * Copyright (c) 2017 Fabrice Bellard
  * Copyright (c) 2018 Charlie Gordon
  *
@@ -83,7 +83,11 @@ int has_suffix(const char *str, const char *suffix)
 
 static void *dbuf_default_realloc(void *opaque, void *ptr, size_t size)
 {
+#if ENABLE_MI_MALLOC
     return mi_realloc(ptr, size);
+#else
+    return realloc(ptr, size);
+#endif
 }
 
 void dbuf_init2(DynBuf *s, void *opaque, DynBufReallocFunc *realloc_func)
@@ -172,7 +176,7 @@ int __attribute__((format(printf, 2, 3))) dbuf_printf(DynBuf *s,
     va_list ap;
     char buf[128];
     int len;
-    
+
     va_start(ap, fmt);
     len = vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
@@ -311,7 +315,7 @@ int utf8_str_len(const uint8_t *p_start, const uint8_t *p_end) {
         }
         count += 1;
     }
-    
+
     return count;
 }
 

--- a/bridge/third_party/quickjs/src/libunicode.c
+++ b/bridge/third_party/quickjs/src/libunicode.c
@@ -1,6 +1,6 @@
 /*
  * Unicode utilities
- * 
+ *
  * Copyright (c) 2017-2018 Fabrice Bellard
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -49,9 +49,9 @@ enum {
 };
 
 /* conv_type:
-   0 = to upper 
+   0 = to upper
    1 = to lower
-   2 = case folding (= to lower with modifications) 
+   2 = case folding (= to lower with modifications)
 */
 int lre_case_conv(uint32_t *res, uint32_t c, int conv_type)
 {
@@ -68,7 +68,7 @@ int lre_case_conv(uint32_t *res, uint32_t c, int conv_type)
     } else {
         uint32_t v, code, data, type, len, a, is_lower;
         int idx, idx_min, idx_max;
-        
+
         is_lower = (conv_type != 0);
         idx_min = 0;
         idx_max = countof(case_conv_table1) - 1;
@@ -208,7 +208,7 @@ static BOOL lre_is_in_table(uint32_t c, const uint8_t *table,
     uint32_t code, b, bit;
     int pos;
     const uint8_t *p;
-    
+
     pos = get_index_pos(&code, c, index_table, index_table_len);
     if (pos < 0)
         return FALSE; /* outside the table */
@@ -241,7 +241,7 @@ BOOL lre_is_cased(uint32_t c)
 {
     uint32_t v, code, len;
     int idx, idx_min, idx_max;
-        
+
     idx_min = 0;
     idx_max = countof(case_conv_table1) - 1;
     while (idx_min <= idx_max) {
@@ -278,9 +278,12 @@ static __maybe_unused void cr_dump(CharRange *cr)
         printf("%d: 0x%04x\n", i, cr->points[i]);
 }
 
-static void *cr_default_realloc(void *opaque, void *ptr, size_t size)
-{
+static void *cr_default_realloc(void *opaque, void *ptr, size_t size) {
+#if ENABLE_MI_MALLOC
     return mi_realloc(ptr, size);
+#else
+    return realloc(ptr, size);
+#endif
 }
 
 void cr_init(CharRange *cr, void *mem_opaque, DynBufReallocFunc *realloc_func)
@@ -300,7 +303,7 @@ int cr_realloc(CharRange *cr, int size)
 {
     int new_size;
     uint32_t *new_buf;
-    
+
     if (size > cr->size) {
         new_size = max_int(size, cr->size * 9 / 2);
         new_buf = cr->realloc_func(cr->mem_opaque, cr->points,
@@ -327,7 +330,7 @@ static void cr_compress(CharRange *cr)
 {
     int i, j, k, len;
     uint32_t *pt;
-    
+
     pt = cr->points;
     len = cr->len;
     i = 0;
@@ -357,7 +360,7 @@ int cr_op(CharRange *cr, const uint32_t *a_pt, int a_len,
 {
     int a_idx, b_idx, is_in;
     uint32_t v;
-    
+
     a_idx = 0;
     b_idx = 0;
     for(;;) {
@@ -658,7 +661,7 @@ static int unicode_decomp_char(uint32_t *res, uint32_t c, BOOL is_compat1)
 {
     uint32_t v, type, is_compat, code, len;
     int idx_min, idx_max, idx;
-    
+
     idx_min = 0;
     idx_max = countof(unicode_decomp_table1) - 1;
     while (idx_min <= idx_max) {
@@ -688,7 +691,7 @@ static int unicode_compose_pair(uint32_t c0, uint32_t c1)
     uint32_t code, len, type, v, idx1, d_idx, d_offset, ch;
     int idx_min, idx_max, idx, d;
     uint32_t pair[2];
-    
+
     idx_min = 0;
     idx_max = countof(unicode_comp_table) - 1;
     while (idx_min <= idx_max) {
@@ -724,7 +727,7 @@ static int unicode_get_cc(uint32_t c)
     uint32_t code, n, type, cc, c1, b;
     int pos;
     const uint8_t *p;
-    
+
     pos = get_index_pos(&code, c,
                         unicode_cc_index, sizeof(unicode_cc_index) / 3);
     if (pos < 0)
@@ -773,7 +776,7 @@ static int unicode_get_cc(uint32_t c)
 static void sort_cc(int *buf, int len)
 {
     int i, j, k, cc, cc1, start, ch1;
-    
+
     for(i = 0; i < len; i++) {
         cc = unicode_get_cc(buf[i]);
         if (cc != 0) {
@@ -812,7 +815,7 @@ static void to_nfd_rec(DynBuf *dbuf,
     uint32_t c, v;
     int i, l;
     uint32_t res[UNICODE_DECOMP_LEN_MAX];
-    
+
     for(i = 0; i < src_len; i++) {
         c = src[i];
         if (c >= 0xac00 && c < 0xd7a4) {
@@ -857,7 +860,7 @@ int unicode_normalize(uint32_t **pdst, const uint32_t *src, int src_len,
     int *buf, buf_len, i, p, starter_pos, cc, last_cc, out_len;
     BOOL is_compat;
     DynBuf dbuf_s, *dbuf = &dbuf_s;
-    
+
     is_compat = n_type >> 1;
 
     dbuf_init2(dbuf, opaque, realloc_func);
@@ -885,15 +888,15 @@ int unicode_normalize(uint32_t **pdst, const uint32_t *src, int src_len,
     }
     buf = (int *)dbuf->buf;
     buf_len = dbuf->size / sizeof(int);
-        
+
     sort_cc(buf, buf_len);
-    
+
     if (buf_len <= 1 || (n_type & 1) != 0) {
         /* NFD / NFKD */
         *pdst = (uint32_t *)buf;
         return buf_len;
     }
-    
+
     i = 1;
     out_len = 1;
     while (i < buf_len) {
@@ -930,7 +933,7 @@ static int unicode_find_name(const char *name_table, const char *name)
     const char *p, *r;
     int pos;
     size_t name_len, len;
-    
+
     p = name_table;
     pos = 0;
     name_len = strlen(name);
@@ -963,13 +966,13 @@ int unicode_script(CharRange *cr,
     CharRange cr1_s, *cr1;
     CharRange cr2_s, *cr2 = &cr2_s;
     BOOL is_common;
-    
+
     script_idx = unicode_find_name(unicode_script_name_table, script_name);
     if (script_idx < 0)
         return -2;
     /* Note: we remove the "Unknown" Script */
     script_idx += UNICODE_SCRIPT_Unknown + 1;
-        
+
     is_common = (script_idx == UNICODE_SCRIPT_Common ||
                  script_idx == UNICODE_SCRIPT_Inherited);
     if (is_ext) {
@@ -1236,7 +1239,7 @@ static int unicode_case1(CharRange *cr, int case_mask)
     }
     return 0;
 }
-        
+
 typedef enum {
     POP_GC,
     POP_PROP,
@@ -1256,7 +1259,7 @@ static int unicode_prop_ops(CharRange *cr, ...)
     CharRange stack[POP_STACK_LEN_MAX];
     int stack_len, op, ret, i;
     uint32_t a;
-    
+
     va_start(ap, cr);
     stack_len = 0;
     for(;;) {
@@ -1342,7 +1345,7 @@ int unicode_general_category(CharRange *cr, const char *gc_name)
 {
     int gc_idx;
     uint32_t gc_mask;
-    
+
     gc_idx = unicode_find_name(unicode_gc_name_table, gc_name);
     if (gc_idx < 0)
         return -2;
@@ -1360,7 +1363,7 @@ int unicode_general_category(CharRange *cr, const char *gc_name)
 int unicode_prop(CharRange *cr, const char *prop_name)
 {
     int prop_idx, ret;
-    
+
     prop_idx = unicode_find_name(unicode_prop_name_table, prop_name);
     if (prop_idx < 0)
         return -2;

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -97,6 +97,10 @@ task('build-darwin-webf-lib', done => {
     externCmakeArgs.push('-DENABLE_ASAN=true');
   }
 
+  if (process.env.USE_SYSTEM_MALLOC === 'true') {
+    externCmakeArgs.push('-DUSE_SYSTEM_MALLOC=true');
+  }
+
   // Bundle quickjs into webf.
   if (program.staticQuickjs) {
     externCmakeArgs.push('-DSTATIC_QUICKJS=true');
@@ -346,6 +350,10 @@ task(`build-ios-webf-lib`, (done) => {
     externCmakeArgs.push('-DSTATIC_QUICKJS=true');
   }
 
+  if (process.env.USE_SYSTEM_MALLOC === 'true') {
+    externCmakeArgs.push('-DUSE_SYSTEM_MALLOC=true');
+  }
+
   // generate build scripts for simulator
   execSync(`cmake -DCMAKE_BUILD_TYPE=${buildType} \
     -DCMAKE_TOOLCHAIN_FILE=${paths.bridge}/cmake/ios.toolchain.cmake \
@@ -485,10 +493,17 @@ task('build-linux-webf-lib', (done) => {
   const buildType = buildMode == 'Release' ? 'Release' : 'Relwithdebinfo';
   const cmakeGeneratorTemplate = platform == 'win32' ? 'Ninja' : 'Unix Makefiles';
 
+  let externCmakeArgs = [];
+
+  if (process.env.USE_SYSTEM_MALLOC === 'true') {
+    externCmakeArgs.push('-DUSE_SYSTEM_MALLOC=true');
+  }
+
   const soBinaryDirectory = path.join(paths.bridge, `build/linux/lib/`);
   const bridgeCmakeDir = path.join(paths.bridge, 'cmake-build-linux');
   // generate project
   execSync(`cmake -DCMAKE_BUILD_TYPE=${buildType} \
+  ${externCmakeArgs.join(' ')} \
   ${isProfile ? '-DENABLE_PROFILE=TRUE \\' : '\\'}
   ${'-DENABLE_TEST=true \\'}
   -G "${cmakeGeneratorTemplate}" \
@@ -563,10 +578,16 @@ task('generate-bindings-code', (done) => {
 task('build-window-webf-lib', (done) => {
   const buildType = buildMode == 'Release' ? 'RelWithDebInfo' : 'Debug';
 
+  let externCmakeArgs = [];
+
+  if (process.env.USE_SYSTEM_MALLOC === 'true') {
+    externCmakeArgs.push('-DUSE_SYSTEM_MALLOC=true');
+  }
+
   const soBinaryDirectory = path.join(paths.bridge, `build/windows/lib/`);
   const bridgeCmakeDir = path.join(paths.bridge, 'cmake-build-windows');
   // generate project
-  execSync(`cmake --log-level=VERBOSE -DCMAKE_BUILD_TYPE=${buildType} -DVERBOSE_CONFIGURE=ON -B ${bridgeCmakeDir} -S ${paths.bridge}`,
+  execSync(`cmake --log-level=VERBOSE -DCMAKE_BUILD_TYPE=${buildType} ${externCmakeArgs.join(' ')} -DVERBOSE_CONFIGURE=ON -B ${bridgeCmakeDir} -S ${paths.bridge}`,
     {
       cwd: paths.bridge,
       stdio: 'inherit',
@@ -626,6 +647,10 @@ task('build-android-webf-lib', (done) => {
 
   if (process.env.ENABLE_ASAN === 'true') {
     externCmakeArgs.push('-DENABLE_ASAN=true');
+  }
+
+  if (process.env.USE_SYSTEM_MALLOC === 'true') {
+    externCmakeArgs.push('-DUSE_SYSTEM_MALLOC=true');
   }
 
   // Bundle quickjs into webf.


### PR DESCRIPTION
Use the system's malloc library instead of the default mimalloc by executing the following commands:

```
USE_SYSTEM_MALLOC=true npm run build:bridge:macos
```