### PR TITLE
fix: fix a crash when a JSObject was finalized after the ExecutingContext was freed.

### DIFF
--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -10,7 +10,10 @@
 namespace webf {
 
 ScriptWrappable::ScriptWrappable(JSContext* ctx)
-    : ctx_(ctx), runtime_(JS_GetRuntime(ctx)), context_(ExecutingContext::From(ctx)), context_id_(context_->contextId()) {}
+    : ctx_(ctx),
+      runtime_(JS_GetRuntime(ctx)),
+      context_(ExecutingContext::From(ctx)),
+      context_id_(context_->contextId()) {}
 
 JSValue ScriptWrappable::ToQuickJS() const {
   return JS_DupValue(ctx_, jsObject_);
@@ -38,7 +41,8 @@ static void HandleJSObjectGCMark(JSRuntime* rt, JSValueConst val, JS_MarkFunc* m
 /// completed.
 static void HandleJSObjectFinalized(JSRuntime* rt, JSValue val) {
   auto* object = static_cast<ScriptWrappable*>(JS_GetOpaque(val, JSValueGetClassId(val)));
-  // When a JSObject got finalized by QuickJS GC, we can not guarantee the ExecutingContext are still alive and accessible.
+  // When a JSObject got finalized by QuickJS GC, we can not guarantee the ExecutingContext are still alive and
+  // accessible.
   if (isContextValid(object->contextId())) {
     ExecutingContext* context = object->GetExecutingContext();
     MemberMutationScope scope{object->GetExecutingContext()};

--- a/bridge/bindings/qjs/script_wrappable.h
+++ b/bridge/bindings/qjs/script_wrappable.h
@@ -55,6 +55,7 @@ class ScriptWrappable : public GarbageCollected<ScriptWrappable> {
   FORCE_INLINE ExecutingContext* GetExecutingContext() const { return context_; };
   FORCE_INLINE JSContext* ctx() const { return ctx_; }
   FORCE_INLINE JSRuntime* runtime() const { return runtime_; }
+  FORCE_INLINE int64_t contextId() const { return context_id_; }
 
   void InitializeQuickJSObject() override;
 
@@ -70,6 +71,7 @@ class ScriptWrappable : public GarbageCollected<ScriptWrappable> {
   JSValue jsObject_{JS_NULL};
   JSContext* ctx_{nullptr};
   ExecutingContext* context_{nullptr};
+  int64_t context_id_;
   JSRuntime* runtime_{nullptr};
   friend class GCVisitor;
 };

--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -35,8 +35,11 @@ BindingObject::~BindingObject() {
   binding_object_->invoke_binding_methods_from_dart = nullptr;
   binding_object_->invoke_bindings_methods_from_native = nullptr;
 
-  GetExecutingContext()->uiCommandBuffer()->addCommand(UICommand::kDisposeBindingObject, nullptr, bindingObject(),
-                                                       nullptr);
+  // When a JSObject got finalized by QuickJS GC, we can not guarantee the ExecutingContext are still alive and accessible.
+  if (isContextValid(contextId())) {
+    GetExecutingContext()->uiCommandBuffer()->addCommand(UICommand::kDisposeBindingObject, nullptr, bindingObject(),
+                                                         nullptr);
+  }
 }
 
 BindingObject::BindingObject(JSContext* ctx, NativeBindingObject* native_binding_object) : ScriptWrappable(ctx) {

--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -35,7 +35,8 @@ BindingObject::~BindingObject() {
   binding_object_->invoke_binding_methods_from_dart = nullptr;
   binding_object_->invoke_bindings_methods_from_native = nullptr;
 
-  // When a JSObject got finalized by QuickJS GC, we can not guarantee the ExecutingContext are still alive and accessible.
+  // When a JSObject got finalized by QuickJS GC, we can not guarantee the ExecutingContext are still alive and
+  // accessible.
   if (isContextValid(contextId())) {
     GetExecutingContext()->uiCommandBuffer()->addCommand(UICommand::kDisposeBindingObject, nullptr, bindingObject(),
                                                          nullptr);

--- a/bridge/core/executing_context.cc
+++ b/bridge/core/executing_context.cc
@@ -20,7 +20,7 @@ namespace webf {
 
 static std::atomic<int32_t> context_unique_id{0};
 
-#define MAX_JS_CONTEXT 1024
+#define MAX_JS_CONTEXT 8192
 bool valid_contexts[MAX_JS_CONTEXT];
 std::atomic<uint32_t> running_context_list{0};
 
@@ -441,7 +441,7 @@ void ExecutingContext::InActiveScriptWrappers(ScriptWrappable* script_wrappable)
   active_wrappers_.erase(script_wrappable);
 }
 
-// An lock free context validator.
+// A lock free context validator.
 bool isContextValid(int32_t contextId) {
   if (contextId > running_context_list)
     return false;

--- a/bridge/test/webf_test_env.cc
+++ b/bridge/test/webf_test_env.cc
@@ -308,12 +308,12 @@ void TEST_onMatchImageSnapshot(void* callbackContext,
 }
 
 void TEST_onMatchImageSnapshotBytes(void* callback_context,
-              int32_t context_id,
-              uint8_t* image_a_bytes,
-              int32_t image_a_size,
-              uint8_t* image_b_bytes,
-              int32_t image_b_size,
-              MatchImageSnapshotCallback callback) {
+                                    int32_t context_id,
+                                    uint8_t* image_a_bytes,
+                                    int32_t image_a_size,
+                                    uint8_t* image_b_bytes,
+                                    int32_t image_b_size,
+                                    MatchImageSnapshotCallback callback) {
   callback(callback_context, contextId, 1, nullptr);
 }
 


### PR DESCRIPTION
When opening multiple WebF pages, all WebF pages share a QuickJS runtime and some JSObjects are shared across multiple pages. When the shared JSObjects are finalized by the GC, the owner ExecutionContext could already be freed, and reading them could cause our apps to exit.

This patch checks whether the ExecutionContext is valid before accessing the ExecutionContext's memory.