### PR TITLE
fix: check ExecutingContext is alive at timer callbacks.

### DIFF
--- a/bridge/core/frame/window_or_worker_global_scope.cc
+++ b/bridge/core/frame/window_or_worker_global_scope.cc
@@ -25,7 +25,8 @@ static void handleTimerCallback(DOMTimer* timer, const char* errmsg) {
 }
 
 static void handleTransientCallback(void* ptr, int32_t contextId, const char* errmsg) {
-  if (!isContextValid(contextId)) return;
+  if (!isContextValid(contextId))
+    return;
 
   auto* timer = static_cast<DOMTimer*>(ptr);
   auto* context = timer->context();
@@ -45,7 +46,8 @@ static void handleTransientCallback(void* ptr, int32_t contextId, const char* er
 }
 
 static void handlePersistentCallback(void* ptr, int32_t contextId, const char* errmsg) {
-  if (!isContextValid(contextId)) return;
+  if (!isContextValid(contextId))
+    return;
 
   auto* timer = static_cast<DOMTimer*>(ptr);
   auto* context = timer->context();

--- a/bridge/core/frame/window_or_worker_global_scope.cc
+++ b/bridge/core/frame/window_or_worker_global_scope.cc
@@ -25,6 +25,8 @@ static void handleTimerCallback(DOMTimer* timer, const char* errmsg) {
 }
 
 static void handleTransientCallback(void* ptr, int32_t contextId, const char* errmsg) {
+  if (!isContextValid(contextId)) return;
+
   auto* timer = static_cast<DOMTimer*>(ptr);
   auto* context = timer->context();
 
@@ -43,6 +45,8 @@ static void handleTransientCallback(void* ptr, int32_t contextId, const char* er
 }
 
 static void handlePersistentCallback(void* ptr, int32_t contextId, const char* errmsg) {
+  if (!isContextValid(contextId)) return;
+
   auto* timer = static_cast<DOMTimer*>(ptr);
   auto* context = timer->context();
 


### PR DESCRIPTION
In some rare user cases, `handleTransientCallback` and `handlePersistentCallback` could be fired when the ExecutionContext has already been freed.