### PR TITLE
fix: fix crashes when working with multiple pages in single flutter engine.

### DIFF
--- a/bridge/bindings/qjs/member_installer.cc
+++ b/bridge/bindings/qjs/member_installer.cc
@@ -27,6 +27,7 @@ static JSValue handleCallThisOnProxy(JSContext* ctx,
                                      JSValueConst* data) {
   JSValue f = data[0];
   JSValue result;
+  JS_UpdateStackTop(JS_GetRuntime(ctx));
   if (JS_IsProxy(this_val)) {
     result = JS_Call(ctx, f, JS_GetProxyTarget(this_val), argc, argv);
   } else {

--- a/bridge/bindings/qjs/qjs_function.cc
+++ b/bridge/bindings/qjs/qjs_function.cc
@@ -57,6 +57,7 @@ ScriptValue QJSFunction::Invoke(JSContext* ctx, const ScriptValue& this_val, int
     argv[0 + i] = arguments[i].QJSValue();
   }
 
+  JS_UpdateStackTop(JS_GetRuntime(ctx));
   JSValue returnValue = JS_Call(ctx, function_, this_val.QJSValue(), argc, argv);
 
   ExecutingContext* context = ExecutingContext::From(ctx);

--- a/bridge/bindings/qjs/script_promise_resolver.cc
+++ b/bridge/bindings/qjs/script_promise_resolver.cc
@@ -36,6 +36,7 @@ ScriptPromise ScriptPromiseResolver::Promise() {
 }
 
 void ScriptPromiseResolver::ResolveOrRejectImmediately(JSValue value) {
+  JS_UpdateStackTop(JS_GetRuntime(context_->ctx()));
   {
     if (state_ == kResolving) {
       JSValue arguments[] = {value};

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -101,6 +101,7 @@ static int HandleJSPropertySetterCallback(JSContext* ctx,
     }
 
     assert_m(JS_IsFunction(ctx, setterFunc), "Setter on prototype should be an function.");
+    JS_UpdateStackTop(JS_GetRuntime(ctx));
     JSValue ret = JS_Call(ctx, setterFunc, obj, 1, &value);
     if (JS_IsException(ret))
       return -1;

--- a/bridge/core/dart_context.cc
+++ b/bridge/core/dart_context.cc
@@ -68,7 +68,10 @@ DartIsolateContext::DartIsolateContext(webf::DartContext* owner_dart_context,
     : owner_dart_context_(owner_dart_context),
       is_valid_(true),
       running_thread_(std::this_thread::get_id()),
-      dart_method_ptr_(std::make_unique<DartMethodPointer>(dart_methods, dart_methods_length)) {}
+      dart_method_ptr_(std::make_unique<DartMethodPointer>(dart_methods, dart_methods_length)) {
+  // Avoid stack overflow when running in multiple threads.
+  JS_UpdateStackTop(dartContext()->runtime());
+}
 
 DartIsolateContext::~DartIsolateContext() {
   is_valid_ = false;

--- a/bridge/core/executing_context.cc
+++ b/bridge/core/executing_context.cc
@@ -121,6 +121,7 @@ bool ExecutingContext::EvaluateJavaScript(const uint16_t* code,
                                           int startLine) {
   std::string utf8Code = toUTF8(std::u16string(reinterpret_cast<const char16_t*>(code), codeLength));
   JSValue result;
+  JS_UpdateStackTop(script_state_.runtime());
   if (parsed_bytecodes == nullptr) {
     result = JS_Eval(script_state_.ctx(), utf8Code.c_str(), utf8Code.size(), sourceURL, JS_EVAL_TYPE_GLOBAL);
   } else {
@@ -144,6 +145,7 @@ bool ExecutingContext::EvaluateJavaScript(const uint16_t* code,
 }
 
 bool ExecutingContext::EvaluateJavaScript(const char16_t* code, size_t length, const char* sourceURL, int startLine) {
+  JS_UpdateStackTop(script_state_.runtime());
   std::string utf8Code = toUTF8(std::u16string(reinterpret_cast<const char16_t*>(code), length));
   JSValue result = JS_Eval(script_state_.ctx(), utf8Code.c_str(), utf8Code.size(), sourceURL, JS_EVAL_TYPE_GLOBAL);
   DrainPendingPromiseJobs();
@@ -153,6 +155,7 @@ bool ExecutingContext::EvaluateJavaScript(const char16_t* code, size_t length, c
 }
 
 bool ExecutingContext::EvaluateJavaScript(const char* code, size_t codeLength, const char* sourceURL, int startLine) {
+  JS_UpdateStackTop(script_state_.runtime());
   JSValue result = JS_Eval(script_state_.ctx(), code, codeLength, sourceURL, JS_EVAL_TYPE_GLOBAL);
   DrainPendingPromiseJobs();
   bool success = HandleException(&result);
@@ -287,6 +290,7 @@ uint8_t* ExecutingContext::DumpByteCode(const char* code,
                                         uint32_t codeLength,
                                         const char* sourceURL,
                                         size_t* bytecodeLength) {
+  JS_UpdateStackTop(script_state_.runtime());
   JSValue object =
       JS_Eval(script_state_.ctx(), code, codeLength, sourceURL, JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_COMPILE_ONLY);
   bool success = HandleException(&object);

--- a/bridge/core/script_state.cc
+++ b/bridge/core/script_state.cc
@@ -14,7 +14,6 @@ thread_local std::atomic<int32_t> runningContexts{0};
 
 ScriptState::ScriptState(DartIsolateContext* dart_context) : dart_isolate_context_(dart_context) {
   runningContexts++;
-  // Avoid stack overflow when running in multiple threads.
   ctx_ = JS_NewContext(dart_isolate_context_->dartContext()->runtime());
   names_installer::Init(ctx_);
 }

--- a/bridge/webf_bridge.cc
+++ b/bridge/webf_bridge.cc
@@ -37,7 +37,9 @@
 #define SYSTEM_NAME "unknown"
 #endif
 
-thread_local webf::DartContext* dart_context_ = nullptr;
+// There will be only 1 flutter ui thread in both single flutter engine and FlutterEngine groups.
+// It ensures there are no conflicts for reading or writing dart_context_ at the same times.
+static webf::DartContext* dart_context_ = nullptr;
 
 void* initDartIsolateContext(uint64_t* dart_methods, int32_t dart_methods_len) {
   if (dart_context_ == nullptr) {


### PR DESCRIPTION
When a Dart isolate is about to exit, it runs the GC before the exit and finalizes all Dart objects. We have registered a callback [here](https://github.com/openwebf/webf/blob/main/bridge/webf_bridge.cc#L161) to be notified and to release a DartIsolateContext when a global Dart object is finalized by the GC.

When the callback is triggered, it may be from one of Dart's worker threads, which isn't the same as Flutter's UI thread. If we use the thread_local keyword for DartContext, the DartIsolateContext created by Flutter's UI can't be freed by Dart's workers. This can cause inconsistencies between DartContext and DartIsolateContexts, which may lead to crashes due to underlying issues in DartIsolateContexts.

This PR was related to https://github.com/openwebf/webf/pull/338

