### PR TITLE
fix: fix crashed when shutdown the app.

### DIFF
--- a/bridge/core/script_state.cc
+++ b/bridge/core/script_state.cc
@@ -25,10 +25,11 @@ JSRuntime* ScriptState::runtime() {
 
 ScriptState::~ScriptState() {
   ctx_invalid_ = true;
+  JSRuntime* rt = JS_GetRuntime(ctx_);
   JS_FreeContext(ctx_);
 
   // Run GC to clean up remaining objects about m_ctx;
-  JS_RunGC(dart_isolate_context_->runtime());
+  JS_RunGC(rt);
 
   ctx_ = nullptr;
 }


### PR DESCRIPTION
DartWorker cannot access the runtime_ member in ScriptState; it only belongs to the Flutter.ui thread.

In this case, we read the JSRuntime from JSContext instead.

```
Thread 20 Crashed:: DartWorker
0   libquickjs.dylib              	       0x10501db28 init_list_head + 0 (list.h:46) [inlined]
1   libquickjs.dylib              	       0x10501db28 gc_decref + 4 (gc.c:696) [inlined]
2   libquickjs.dylib              	       0x10501db28 JS_RunGC + 28 (gc.c:797)
3   libwebf.dylib                 	       0x10555b750 webf::ScriptState::~ScriptState() + 24 (script_state.cc:31) [inlined]
4   libwebf.dylib                 	       0x10555b750 webf::ScriptState::~ScriptState() + 44 (script_state.cc:26)
5   libwebf.dylib                 	       0x1055598c8 webf::ExecutingContext::~ExecutingContext() + 688 (executing_context.cc:110)
6   libwebf.dylib                 	       0x105559bd0 webf::ExecutingContext::~ExecutingContext() + 12 (executing_context.cc:92)
7   libwebf.dylib                 	       0x10555c06c webf::WebFPage::~WebFPage() + 28 (page.cc:150) [inlined]
8   libwebf.dylib                 	       0x10555c06c webf::WebFPage::~WebFPage() + 44 (page.cc:144)
9   libwebf.dylib                 	       0x10555c728 std::__1::default_delete<webf::WebFPage>::operator()[abi:v15006](webf::WebFPage*) const + 4 (unique_ptr.h:48) [inlined]

```