### PR TITLE
fix: fix Resource temporarily unavailable for Hive lock file.

### DIFF
--- a/webf/lib/src/module/local_storage.dart
+++ b/webf/lib/src/module/local_storage.dart
@@ -24,7 +24,12 @@ class LocalStorageModule extends BaseModule {
     String tmpPath = await getWebFTemporaryPath();
     Hive.init(path.join(tmpPath, 'LocalStorage'));
     String key = getBoxKey(moduleManager!);
-    await Hive.openBox(key);
+    try {
+      await Hive.openBox(key);
+    } catch (e) {
+      // Try twice to avoid Resource temporarily unavailable.
+      await Hive.openBox(key);
+    }
   }
 
   LocalStorageModule(ModuleManager? moduleManager) : super(moduleManager);


### PR DESCRIPTION
Hive only supports accessing a resource from one instance, and it creates a lock file to avoid conflicts.

If two Dart isolates load the same URL of WebF pages, they will point to the same Hive lock file and report the following error:
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: FileSystemException: lock failed, path = '/Users/andycall.dong/Library/Caches/WebF/LocalStorage/_webf_11988048.lock' (OS Error: Resource temporarily unavailable, errno = 35)
#0      _RandomAccessFile.lock.<anonymous closure> (dart:io/file_impl.dart:1002:9)
<asynchronous suspension>
#1      StorageBackendVm.initialize (package:hive/src/backend/vm/storage_backend_vm.dart:81:5)
<asynchronous suspension>
#2      HiveImpl._openBox (package:hive/src/hive_impl.dart:111:9)
<asynchronous suspension>
#3      HiveImpl.openBox (package:hive/src/hive_impl.dart:142:12)
<asynchronous suspension>
```

This patch will attempt to initialize the Hive box twice. When the first load encounters the above error, the second try will remove the lock file and successfully initialize the box.