### PR TITLE
fix: fix member of ScriptWrappable not tracked by GC.

### DIFF
--- a/bridge/bindings/qjs/cppgc/gc_visitor.cc
+++ b/bridge/bindings/qjs/cppgc/gc_visitor.cc
@@ -7,7 +7,7 @@
 
 namespace webf {
 
-void GCVisitor::Trace(JSValue value) {
+void GCVisitor::TraceValue(JSValue value) {
   JS_MarkValue(runtime_, value, markFunc_);
 }
 

--- a/bridge/bindings/qjs/cppgc/gc_visitor.h
+++ b/bridge/bindings/qjs/cppgc/gc_visitor.h
@@ -24,13 +24,13 @@ class GCVisitor final {
   explicit GCVisitor(JSRuntime* rt, JS_MarkFunc* markFunc) : runtime_(rt), markFunc_(markFunc){};
 
   template <typename T>
-  void Trace(const Member<T>& target) {
+  void TraceMember(const Member<T>& target) {
     if (target.Get() != nullptr) {
       JS_MarkValue(runtime_, target.Get()->jsObject_, markFunc_);
     }
   };
 
-  void Trace(JSValue value);
+  void TraceValue(JSValue value);
 
  private:
   JSRuntime* runtime_{nullptr};

--- a/bridge/bindings/qjs/cppgc/trace_if_needed.h
+++ b/bridge/bindings/qjs/cppgc/trace_if_needed.h
@@ -57,7 +57,7 @@ struct TraceIfNeeded<IDLSequence<T>> : TraceIfNeededBase<IDLSequence<T>> {
 
 template <typename T>
 struct TraceIfNeeded<T, typename std::enable_if_t<std::is_base_of<ScriptWrappable, T>::value>> {
-  static void Trace(GCVisitor* visitor, const Member<T>& value) { visitor->Trace(value); }
+  static void Trace(GCVisitor* visitor, const Member<T>& value) { visitor->TraceMember(value); }
 };
 
 template <>

--- a/bridge/bindings/qjs/heap_hashmap.h
+++ b/bridge/bindings/qjs/heap_hashmap.h
@@ -68,7 +68,7 @@ void HeapHashMap<K, V>::Erase(K key) {
 template <typename K, typename V>
 void HeapHashMap<K, V>::Trace(GCVisitor* visitor) const {
   for (auto& entry : entries_) {
-    visitor->Trace(entry.second);
+    visitor->TraceMember(entry.second);
   }
 }
 

--- a/bridge/bindings/qjs/heap_vector.h
+++ b/bridge/bindings/qjs/heap_vector.h
@@ -21,7 +21,7 @@ class HeapVector final {
 template <typename V>
 void HeapVector<V>::Trace(GCVisitor* visitor) const {
   for (auto& item : entries_) {
-    visitor->Trace(item);
+    visitor->TraceValue(item);
   }
 }
 

--- a/bridge/bindings/qjs/qjs_function.cc
+++ b/bridge/bindings/qjs/qjs_function.cc
@@ -71,7 +71,7 @@ ScriptValue QJSFunction::Invoke(JSContext* ctx, const ScriptValue& this_val, int
 }
 
 void QJSFunction::Trace(GCVisitor* visitor) const {
-  visitor->Trace(function_);
+  visitor->TraceValue(function_);
 }
 
 }  // namespace webf

--- a/bridge/bindings/qjs/script_promise_resolver.cc
+++ b/bridge/bindings/qjs/script_promise_resolver.cc
@@ -26,9 +26,9 @@ ScriptPromiseResolver::~ScriptPromiseResolver() {
 }
 
 void ScriptPromiseResolver::Trace(GCVisitor* visitor) const {
-  visitor->Trace(promise_);
-  visitor->Trace(resolve_func_);
-  visitor->Trace(reject_func_);
+  visitor->TraceValue(promise_);
+  visitor->TraceValue(resolve_func_);
+  visitor->TraceValue(reject_func_);
 }
 
 ScriptPromise ScriptPromiseResolver::Promise() {

--- a/bridge/bindings/qjs/script_value.cc
+++ b/bridge/bindings/qjs/script_value.cc
@@ -219,7 +219,7 @@ bool ScriptValue::IsBool() const {
 }
 
 void ScriptValue::Trace(GCVisitor* visitor) const {
-  visitor->Trace(value_);
+  visitor->TraceValue(value_);
 }
 
 }  // namespace webf

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -28,7 +28,7 @@ ScriptValue ScriptWrappable::ToValue() {
 }
 
 /// This callback will be called when QuickJS GC is running at marking stage.
-/// Users of this class should override `void Trace(JSRuntime* rt, JSValueConst val, JS_MarkFunc* mark_func)` to
+/// Users of this class should override `void TraceMember(JSRuntime* rt, JSValueConst val, JS_MarkFunc* mark_func)` to
 /// tell GC which member of their class should be collected by GC.
 static void HandleJSObjectGCMark(JSRuntime* rt, JSValueConst val, JS_MarkFunc* mark_func) {
   auto* object = static_cast<ScriptWrappable*>(JS_GetOpaque(val, JSValueGetClassId(val)));

--- a/bridge/core/css/inline_css_style_declaration.cc
+++ b/bridge/core/css/inline_css_style_declaration.cc
@@ -104,7 +104,7 @@ void InlineCssStyleDeclaration::CopyWith(InlineCssStyleDeclaration* inline_style
 }
 
 void InlineCssStyleDeclaration::Trace(GCVisitor* visitor) const {
-  visitor->Trace(owner_element_);
+  visitor->TraceMember(owner_element_);
 }
 
 std::string InlineCssStyleDeclaration::ToString() const {

--- a/bridge/core/dom/child_node_list.cc
+++ b/bridge/core/dom/child_node_list.cc
@@ -54,7 +54,7 @@ Node* ChildNodeList::TraverseBackwardToOffset(unsigned offset, Node& current_nod
 }
 
 void ChildNodeList::Trace(GCVisitor* visitor) const {
-  visitor->Trace(parent_);
+  visitor->TraceMember(parent_);
   collection_index_cache_.Trace(visitor);
   NodeList::Trace(visitor);
 }

--- a/bridge/core/dom/collection_index_cache.h
+++ b/bridge/core/dom/collection_index_cache.h
@@ -70,7 +70,7 @@ class CollectionIndexCache {
   void NodeInserted();
   void NodeRemoved();
 
-  virtual void Trace(GCVisitor* visitor) const { visitor->Trace(current_node_); }
+  virtual void Trace(GCVisitor* visitor) const { visitor->TraceMember(current_node_); }
 
  protected:
   FORCE_INLINE NodeType* CachedNode() const { return current_node_.Get(); }

--- a/bridge/core/dom/collection_items_cache.h
+++ b/bridge/core/dom/collection_items_cache.h
@@ -47,7 +47,7 @@ class CollectionItemsCache : public CollectionIndexCache<Collection, NodeType> {
   ~CollectionItemsCache();
 
   void Trace(GCVisitor* visitor) const override {
-    visitor->Trace(cached_list_);
+    visitor->TraceValue(cached_list_);
     Base::Trace(visitor);
   }
 

--- a/bridge/core/dom/container_node.cc
+++ b/bridge/core/dom/container_node.cc
@@ -458,8 +458,8 @@ void ContainerNode::NotifyNodeRemoved(Node& root) {
 }
 
 void ContainerNode::Trace(GCVisitor* visitor) const {
-  visitor->Trace(first_child_);
-  visitor->Trace(last_child_);
+  visitor->TraceMember(first_child_);
+  visitor->TraceMember(last_child_);
 
   Node::Trace(visitor);
 }

--- a/bridge/core/dom/dom_string_map.cc
+++ b/bridge/core/dom/dom_string_map.cc
@@ -163,7 +163,7 @@ bool DOMStringMap::DeleteItem(const webf::AtomicString& key, webf::ExceptionStat
 }
 
 void DOMStringMap::Trace(webf::GCVisitor* visitor) const {
-  visitor->Trace(owner_element_);
+  visitor->TraceMember(owner_element_);
 }
 
 }  // namespace webf

--- a/bridge/core/dom/dom_token_list.cc
+++ b/bridge/core/dom/dom_token_list.cc
@@ -108,7 +108,7 @@ void DOMTokenList::Remove(const AtomicString& token) {
 }
 
 void DOMTokenList::Trace(GCVisitor* visitor) const {
-  visitor->Trace(element_);
+  visitor->TraceMember(element_);
 }
 
 bool DOMTokenList::NamedPropertyQuery(const AtomicString& key, ExceptionState& exception_state) {

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -308,8 +308,8 @@ bool Element::IsWidgetElement() const {
 }
 
 void Element::Trace(GCVisitor* visitor) const {
-  visitor->Trace(attributes_);
-  visitor->Trace(cssom_wrapper_);
+  visitor->TraceMember(attributes_);
+  visitor->TraceMember(cssom_wrapper_);
   if (element_data_ != nullptr) {
     element_data_->Trace(visitor);
   }

--- a/bridge/core/dom/element_data.cc
+++ b/bridge/core/dom/element_data.cc
@@ -10,8 +10,8 @@ namespace webf {
 void ElementData::CopyWith(ElementData* other) {}
 
 void ElementData::Trace(GCVisitor* visitor) const {
-  visitor->Trace(class_lists_);
-  visitor->Trace(data_set_);
+  visitor->TraceMember(class_lists_);
+  visitor->TraceMember(data_set_);
 }
 
 DOMTokenList* ElementData::GetClassList() const {

--- a/bridge/core/dom/events/event.cc
+++ b/bridge/core/dom/events/event.cc
@@ -208,8 +208,8 @@ void Event::SetHandlingPassive(PassiveMode mode) {
 }
 
 void Event::Trace(GCVisitor* visitor) const {
-  visitor->Trace(target_);
-  visitor->Trace(current_target_);
+  visitor->TraceMember(target_);
+  visitor->TraceMember(current_target_);
 }
 
 }  // namespace webf

--- a/bridge/core/dom/legacy/element_attributes.cc
+++ b/bridge/core/dom/legacy/element_attributes.cc
@@ -119,7 +119,7 @@ std::unordered_map<AtomicString, AtomicString>::iterator ElementAttributes::end(
 }
 
 void ElementAttributes::Trace(GCVisitor* visitor) const {
-  visitor->Trace(element_);
+  visitor->TraceMember(element_);
 }
 
 }  // namespace webf

--- a/bridge/core/dom/live_node_list_base.h
+++ b/bridge/core/dom/live_node_list_base.h
@@ -73,7 +73,7 @@ class LiveNodeListBase : public GarbageCollected<LiveNodeListBase> {
 
   static bool ShouldInvalidateTypeOnAttributeChange(NodeListInvalidationType, const AtomicString&);
 
-  void Trace(GCVisitor* visitor) const override { visitor->Trace(owner_node_); }
+  void Trace(GCVisitor* visitor) const override { visitor->TraceMember(owner_node_); }
 
  protected:
   Document& GetDocument() const { return owner_node_->GetDocument(); }

--- a/bridge/core/dom/node.cc
+++ b/bridge/core/dom/node.cc
@@ -584,9 +584,9 @@ Node::Node(ExecutingContext* context, TreeScope* tree_scope, ConstructionType ty
 Node::~Node() {}
 
 void Node::Trace(GCVisitor* visitor) const {
-  visitor->Trace(previous_);
-  visitor->Trace(next_);
-  visitor->Trace(parent_or_shadow_host_node_);
+  visitor->TraceMember(previous_);
+  visitor->TraceMember(next_);
+  visitor->TraceMember(parent_or_shadow_host_node_);
   if (node_data_ != nullptr)
     node_data_->Trace(visitor);
   if (event_target_data_ != nullptr) {

--- a/bridge/core/dom/node_data.cc
+++ b/bridge/core/dom/node_data.cc
@@ -35,7 +35,7 @@ EmptyNodeList* NodeData::EnsureEmptyChildNodeList(Node& node) {
 
 void NodeData::Trace(GCVisitor* visitor) const {
   if (child_node_list_ != nullptr) {
-    visitor->Trace(child_node_list_->ToQuickJSUnsafe());
+    visitor->TraceValue(child_node_list_->ToQuickJSUnsafe());
   }
 }
 

--- a/bridge/core/events/mouse_event.cc
+++ b/bridge/core/events/mouse_event.cc
@@ -126,7 +126,7 @@ bool MouseEvent::IsMouseEvent() const {
 }
 
 void MouseEvent::Trace(GCVisitor* visitor) const {
-  visitor->Trace(related_target_);
+  visitor->TraceMember(related_target_);
   UIEvent::Trace(visitor);
 }
 

--- a/bridge/core/events/touch_event.cc
+++ b/bridge/core/events/touch_event.cc
@@ -85,9 +85,9 @@ TouchList* TouchEvent::targetTouches() const {
 }
 
 void TouchEvent::Trace(GCVisitor* visitor) const {
-  visitor->Trace(touches_);
-  visitor->Trace(changed_touches_);
-  visitor->Trace(target_touches_);
+  visitor->TraceMember(touches_);
+  visitor->TraceMember(changed_touches_);
+  visitor->TraceMember(target_touches_);
   UIEvent::Trace(visitor);
 }
 

--- a/bridge/core/events/ui_event.cc
+++ b/bridge/core/events/ui_event.cc
@@ -78,7 +78,7 @@ bool UIEvent::IsUiEvent() const {
 }
 
 void UIEvent::Trace(GCVisitor* visitor) const {
-  visitor->Trace(view_);
+  visitor->TraceMember(view_);
   Event::Trace(visitor);
 }
 

--- a/bridge/core/frame/window.cc
+++ b/bridge/core/frame/window.cc
@@ -237,7 +237,7 @@ bool Window::IsWindowOrWorkerGlobalScope() const {
 }
 
 void Window::Trace(GCVisitor* visitor) const {
-  visitor->Trace(screen_);
+  visitor->TraceMember(screen_);
   EventTargetWithInlineData::Trace(visitor);
 }
 

--- a/bridge/core/html/canvas/html_canvas_element.cc
+++ b/bridge/core/html/canvas/html_canvas_element.cc
@@ -32,7 +32,7 @@ CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, 
 
 void HTMLCanvasElement::Trace(GCVisitor* visitor) const {
   for (auto&& context : running_context_2ds_) {
-    visitor->Trace(context);
+    visitor->TraceMember(context);
   }
   HTMLElement::Trace(visitor);
 }

--- a/bridge/core/html/html_template_element.cc
+++ b/bridge/core/html/html_template_element.cc
@@ -23,7 +23,7 @@ DocumentFragment* HTMLTemplateElement::ContentInternal() const {
 }
 
 void HTMLTemplateElement::Trace(webf::GCVisitor* visitor) const {
-  visitor->Trace(content_);
+  visitor->TraceMember(content_);
 }
 
 }  // namespace webf

--- a/bridge/core/input/touch.cc
+++ b/bridge/core/input/touch.cc
@@ -112,7 +112,7 @@ EventTarget* Touch::target() const {
 }
 
 void Touch::Trace(GCVisitor* visitor) const {
-  visitor->Trace(target_);
+  visitor->TraceMember(target_);
 }
 
 }  // namespace webf

--- a/bridge/core/input/touch_list.cc
+++ b/bridge/core/input/touch_list.cc
@@ -3,6 +3,7 @@
  */
 
 #include "touch_list.h"
+#include "bindings/qjs/cppgc/gc_visitor.h"
 #include "touch.h"
 
 namespace webf {
@@ -57,7 +58,7 @@ void TouchList::NamedPropertyEnumerator(std::vector<AtomicString>& props, Except
 
 void TouchList::Trace(GCVisitor* visitor) const {
   for (auto& item : values_) {
-    item->Trace(visitor);
+    visitor->TraceMember(item);
   }
 }
 

--- a/bridge/core/timing/performance.cc
+++ b/bridge/core/timing/performance.cc
@@ -166,7 +166,7 @@ void Performance::clearMeasures(const AtomicString& name, ExceptionState& except
 
 void Performance::Trace(GCVisitor* visitor) const {
   for (auto& entries : entries_) {
-    visitor->Trace(entries);
+    visitor->TraceMember(entries);
   }
 }
 


### PR DESCRIPTION
The basic rule when using <Member> in ScriptWrappable is that it must be tracked by GCVisitor.


This patch fixes a bug in touch_list.cc caused by the Trace() function bypassing the aforementioned rules.


```before
void TouchList::Trace(GCVisitor* visitor) const {
  for (auto& item : values_) {
    item->Trace(visitor); // This line of code bypass the tracing of GC.
  }
}
```