### PR TITLE
fix: fix built-in string initialized multiples and cause leaks.

### DIFF
--- a/bridge/core/dart_isolate_context.cc
+++ b/bridge/core/dart_isolate_context.cc
@@ -20,7 +20,15 @@ const std::unique_ptr<DartContextData>& DartIsolateContext::EnsureData() const {
 }
 
 thread_local JSRuntime* DartIsolateContext::runtime_{nullptr};
+thread_local bool is_name_installed_ = false;
 thread_local int64_t running_isolates_ = 0;
+
+void initializeBuiltInStrings(JSContext* ctx) {
+  if (!is_name_installed_) {
+    names_installer::Init(ctx);
+    is_name_installed_ = true;
+  }
+}
 
 DartIsolateContext::DartIsolateContext(const uint64_t* dart_methods, int32_t dart_methods_length)
     : is_valid_(true),
@@ -54,6 +62,7 @@ DartIsolateContext::~DartIsolateContext() {
     data_.reset();
     JS_FreeRuntime(runtime_);
     runtime_ = nullptr;
+    is_name_installed_ = false;
   }
 }
 

--- a/bridge/core/dart_isolate_context.h
+++ b/bridge/core/dart_isolate_context.h
@@ -14,6 +14,8 @@ namespace webf {
 class WebFPage;
 class DartIsolateContext;
 
+void initializeBuiltInStrings(JSContext* ctx);
+
 // DartIsolateContext has a 1:1 correspondence with a dart isolates.
 class DartIsolateContext {
  public:

--- a/bridge/core/dom/document.cc
+++ b/bridge/core/dom/document.cc
@@ -219,10 +219,10 @@ std::vector<Element*> Document::getElementsByName(const AtomicString& name, Exce
 
 Element* Document::elementFromPoint(double x, double y, ExceptionState& exception_state) {
   GetExecutingContext()->FlushUICommand();
-    const NativeValue args[] = {
-        NativeValueConverter<NativeTypeDouble>::ToNativeValue(x),
-        NativeValueConverter<NativeTypeDouble>::ToNativeValue(y),
-    };
+  const NativeValue args[] = {
+      NativeValueConverter<NativeTypeDouble>::ToNativeValue(x),
+      NativeValueConverter<NativeTypeDouble>::ToNativeValue(y),
+  };
   NativeValue result = InvokeBindingMethod(binding_call_methods::kelementFromPoint, 2, args, exception_state);
   if (exception_state.HasException()) {
     return nullptr;

--- a/bridge/core/script_state.cc
+++ b/bridge/core/script_state.cc
@@ -16,7 +16,7 @@ ScriptState::ScriptState(DartIsolateContext* dart_context) : dart_isolate_contex
   runningContexts++;
   // Avoid stack overflow when running in multiple threads.
   ctx_ = JS_NewContext(dart_isolate_context_->runtime());
-  names_installer::Init(ctx_);
+  initializeBuiltInStrings(ctx_);
 }
 
 JSRuntime* ScriptState::runtime() {

--- a/bridge/webf_bridge_test.cc
+++ b/bridge/webf_bridge_test.cc
@@ -29,6 +29,7 @@ void handler(int sig) {
 
 void* initTestFramework(void* page_) {
   signal(SIGSEGV, handler);  // install handler when crashed.
+  signal(SIGABRT, handler);
   auto page = reinterpret_cast<webf::WebFPage*>(page_);
   assert(std::this_thread::get_id() == page->currentThread());
   return new webf::WebFTestContext(page->GetExecutingContext());


### PR DESCRIPTION
Built-in strings should be initialized once for a corresponding JSRuntime.