### PR TITLE
feat: support receive binary data from fetch and XMLHttpRequest.

### DIFF
--- a/bridge/foundation/native_value.h
+++ b/bridge/foundation/native_value.h
@@ -25,6 +25,7 @@ enum NativeTag {
   TAG_POINTER = 7,
   TAG_FUNCTION = 8,
   TAG_ASYNC_FUNCTION = 9,
+  TAG_UINT8_BYTES = 10,
 };
 
 enum class JSPointerType { NativeBindingObject = 0, Others = 1 };

--- a/bridge/polyfill/src/fetch.ts
+++ b/bridge/polyfill/src/fetch.ts
@@ -85,7 +85,7 @@ export class Headers implements Headers {
 class Body {
   // TODO support readableStream
   _bodyInit: any;
-  body: string | null;
+  body: string | null | Blob;
   bodyUsed: boolean;
   headers: Headers;
 
@@ -100,6 +100,8 @@ class Body {
       this.body = '';
     } else if (typeof body === 'string') {
       this.body = body;
+    } else if (Object.prototype.toString.call(body) == '[object ArrayBuffer]') {
+      this.body = new Blob([body as ArrayBuffer]);
     } else {
       this.body = body = Object.prototype.toString.call(body);
     }
@@ -112,11 +114,21 @@ class Body {
   }
 
   arrayBuffer(): Promise<ArrayBuffer> {
-    throw new Error('not supported');
+    if (!this.body) return Promise.resolve(new ArrayBuffer(0));
+
+    if (typeof this.body === 'string') {
+      return new Blob([this.body]).arrayBuffer();
+    }
+    return this.body.arrayBuffer();
   }
 
-  blob(): Promise<Blob> {
-    throw new Error('not supported');
+  async blob(): Promise<Blob> {
+    if (!this.body) new Blob([]);
+
+    if (typeof this.body === 'string') {
+      return new Blob([this.body]);
+    }
+    return this.body as Blob;
   }
 
   formData(): Promise<FormData> {
@@ -129,7 +141,13 @@ class Body {
     }
 
     this.bodyUsed = true;
-    return JSON.parse(this.body);
+
+    if (typeof this.body === 'string') {
+      return JSON.parse(this.body);
+    }
+
+    const txt = await this.body.text();
+    return JSON.parse(txt);
   }
 
   async text(): Promise<string> {
@@ -138,7 +156,14 @@ class Body {
       return rejected;
     }
     this.bodyUsed = true;
-    return this.body || '';
+
+    if (!this.body) return '';
+
+    if (typeof this.body === 'string') {
+      return this.body || '';
+    }
+
+    return this.body.text();
   }
 }
 

--- a/integration_tests/specs/fetch/fetch.ts
+++ b/integration_tests/specs/fetch/fetch.ts
@@ -423,6 +423,28 @@ describe('Response', function() {
           );
         });
     });
+
+    it('should works when response as arraybuffer', async function() {
+      return fetch('https://andycall.oss-cn-beijing.aliyuncs.com/data/data.json')
+          .then(function(response) {
+            return response.arrayBuffer();
+          })
+          .catch(function(error) {
+            console.assert(
+                error instanceof Error,
+                'Promise rejected after body consumed'
+            );
+          }).then(async (buffer: ArrayBuffer) => {
+            expect(buffer instanceof ArrayBuffer);
+            const blob = new Blob([buffer]);
+            expect(await blob.text()).toBe(`{
+    "method": "GET",
+    "data": {
+        "userName": "12345"
+    }
+}`);
+          });
+    });
   });
 
   describe('text', function() {

--- a/integration_tests/specs/xhr/xhr.ts
+++ b/integration_tests/specs/xhr/xhr.ts
@@ -71,4 +71,94 @@ describe('XMLHttpRequest', () => {
     xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     xhr.send('foobar');
   });
+
+  it('should works when setting responseType to arraybuffer',  (done) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = async function() {
+      if (xhr.readyState == 4) {
+        let arrayBuffer = xhr.response;
+        assert_true(arrayBuffer instanceof ArrayBuffer);
+        let blob = new Blob([arrayBuffer]);
+        let text = await blob.text();
+        expect(text).toEqual(`{
+    "method": "GET",
+    "data": {
+        "userName": "12345"
+    }
+}`);
+        done();
+      }
+    };
+    xhr.responseType = 'arraybuffer';
+    xhr.open('GET', 'https://andycall.oss-cn-beijing.aliyuncs.com/data/data.json', true);
+    xhr.setRequestHeader('Accept', 'application/json');
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.send();
+  });
+
+  it('should works when setting responseType to blob',  (done) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = async function() {
+      if (xhr.readyState == 4) {
+        let blob = xhr.response;
+        assert_true(blob instanceof Blob);
+        let text = await blob.text();
+        expect(text).toEqual(`{
+    "method": "GET",
+    "data": {
+        "userName": "12345"
+    }
+}`);
+        done();
+      }
+    };
+    xhr.responseType = 'blob';
+    xhr.open('GET', 'https://andycall.oss-cn-beijing.aliyuncs.com/data/data.json', true);
+    xhr.setRequestHeader('Accept', 'application/json');
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.send();
+  });
+
+  it('should works when setting responseType to blob',  (done) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = async function() {
+      if (xhr.readyState == 4) {
+        let text = xhr.response;
+        expect(xhr.responseText).toEqual(text);
+        expect(text).toEqual(`{
+    "method": "GET",
+    "data": {
+        "userName": "12345"
+    }
+}`);
+        done();
+      }
+    };
+    xhr.responseType = '';
+    xhr.open('GET', 'https://andycall.oss-cn-beijing.aliyuncs.com/data/data.json', true);
+    xhr.setRequestHeader('Accept', 'application/json');
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.send();
+  });
+
+  it('should works when setting responseType to json',  (done) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = async function() {
+      if (xhr.readyState == 4) {
+        let json = xhr.response;
+        expect(json).toEqual({
+          "method": "GET",
+          "data": {
+            "userName": "12345"
+          }
+        });
+        done();
+      }
+    };
+    xhr.responseType = 'json';
+    xhr.open('GET', 'https://andycall.oss-cn-beijing.aliyuncs.com/data/data.json', true);
+    xhr.setRequestHeader('Accept', 'application/json');
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.send();
+  });
 });

--- a/webf/lib/src/bridge/native_value.dart
+++ b/webf/lib/src/bridge/native_value.dart
@@ -83,6 +83,9 @@ dynamic fromNativeValue(Pointer<NativeValue> nativeValue) {
       dynamic value = jsonDecode(nativeStringToString(nativeString));
       freeNativeString(nativeString);
       return value;
+    case JSValueType.TAG_UINT8_BYTES:
+      Pointer<Uint8> buffer = Pointer.fromAddress(nativeValue.ref.u);
+      return buffer.asTypedList(nativeValue.ref.uint32);
   }
 }
 

--- a/webf/lib/src/bridge/native_value.dart
+++ b/webf/lib/src/bridge/native_value.dart
@@ -4,6 +4,7 @@
  */
 import 'dart:convert';
 import 'dart:ffi';
+import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:webf/bridge.dart';
@@ -30,7 +31,8 @@ enum JSValueType {
   TAG_LIST,
   TAG_POINTER,
   TAG_FUNCTION,
-  TAG_ASYNC_FUNCTION
+  TAG_ASYNC_FUNCTION,
+  TAG_UINT8_BYTES
 }
 
 enum JSPointerType {
@@ -104,6 +106,13 @@ void toNativeValue(Pointer<NativeValue> target, value, [BindingObject? ownerBind
     target.ref.tag = JSValueType.TAG_POINTER.index;
     target.ref.uint32 = JSPointerType.Others.index;
     target.ref.u = value.address;
+  } else if (value is Uint8List) {
+    Pointer<Uint8> buffer = malloc.allocate(sizeOf<Uint8>() * value.length);
+    final bytes = buffer.asTypedList(value.length);
+    bytes.setAll(0, value);
+    target.ref.tag = JSValueType.TAG_UINT8_BYTES.index;
+    target.ref.uint32 = value.length;
+    target.ref.u = buffer.address;
   } else if (value is BindingObject) {
     assert((value.pointer)!.address != nullptr);
     target.ref.tag = JSValueType.TAG_POINTER.index;

--- a/webf/lib/src/module/fetch.dart
+++ b/webf/lib/src/module/fetch.dart
@@ -113,13 +113,8 @@ class FetchModule extends BaseModule {
           return consolidateHttpClientResponseBytes(res);
         }
       }).then((Uint8List? bytes) {
-        if (bytes == null)
-          return Future.value(null);
-        else
-          return resolveStringFromData(bytes);
-      }).then((String? content) {
-        if (content != null) {
-          callback(data: [EMPTY_STRING, response?.statusCode, content]);
+        if (bytes != null) {
+          callback(data: [EMPTY_STRING, response?.statusCode, bytes]);
         } else {
           throw FlutterError('Failed to read response.');
         }


### PR DESCRIPTION
1. Add support for setting the [responseType](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType) property to 'arraybuffer' or 'blob' on XMLHttpRequest object to receive binary data instead of json or string.
2. Add support for [Response.arraybuffer()](https://developer.mozilla.org/en-US/docs/Web/API/Response/arrayBuffer) method and [Response.blob()](https://developer.mozilla.org/en-US/docs/Web/API/Response/blob) method.