### PR TITLE
fix: fix constructor property on DOM elements.

### DIFF
--- a/bridge/bindings/qjs/cppgc/member.h
+++ b/bridge/bindings/qjs/cppgc/member.h
@@ -39,7 +39,7 @@ class Member {
       //  Two is by free directly when running out of function body.
       // We detect the GC phase to handle case two, and free our members by hand(call JS_FreeValueRT directly).
       JSGCPhaseEnum phase = JS_GetEnginePhase(runtime_);
-      if (phase == JS_GC_PHASE_DECREF) {
+      if (phase == JS_GC_PHASE_DECREF || phase == JS_GC_PHASE_REMOVE_CYCLES) {
         JS_FreeValueRT(runtime_, raw_->ToQuickJSUnsafe());
       }
     }

--- a/bridge/bindings/qjs/cppgc/member.h
+++ b/bridge/bindings/qjs/cppgc/member.h
@@ -30,6 +30,7 @@ class Member {
   Member(const Member<T>& other) {
     raw_ = other.raw_;
     runtime_ = other.runtime_;
+    js_object_ptr_ = other.js_object_ptr_;
   }
   ~Member() {
     if (raw_ != nullptr) {
@@ -40,7 +41,7 @@ class Member {
       // We detect the GC phase to handle case two, and free our members by hand(call JS_FreeValueRT directly).
       JSGCPhaseEnum phase = JS_GetEnginePhase(runtime_);
       if (phase == JS_GC_PHASE_DECREF || phase == JS_GC_PHASE_REMOVE_CYCLES) {
-        JS_FreeValueRT(runtime_, raw_->ToQuickJSUnsafe());
+        JS_FreeValueRT(runtime_, JS_MKPTR(JS_TAG_OBJECT, js_object_ptr_));
       }
     }
   };
@@ -53,7 +54,7 @@ class Member {
 
     if (phase == JS_GC_PHASE_REMOVE_CYCLES) {
       // Free the pointer immediately if parent object are removed by GC.
-      JS_FreeValueRT(runtime_, raw_->ToQuickJSUnsafe());
+      JS_FreeValueRT(runtime_, JS_MKPTR(JS_TAG_OBJECT, js_object_ptr_));
     } else {
       auto* wrappable = To<ScriptWrappable>(raw_);
       assert(wrappable->GetExecutingContext()->HasMutationScope());
@@ -61,12 +62,14 @@ class Member {
       wrappable->GetExecutingContext()->mutationScope()->RecordFree(wrappable);
     }
     raw_ = nullptr;
+    js_object_ptr_ = nullptr;
   }
 
   // Copy assignment.
   Member& operator=(const Member& other) {
     raw_ = other.raw_;
     runtime_ = other.runtime_;
+    js_object_ptr_ = other.js_object_ptr_;
     return *this;
   }
   // Move assignment.
@@ -98,12 +101,14 @@ class Member {
       assert_m(wrappable->GetExecutingContext()->HasMutationScope(),
                "Member must be used after MemberMutationScope allcated.");
       runtime_ = wrappable->runtime();
+      js_object_ptr_ = JS_VALUE_GET_PTR(wrappable->ToQuickJSUnsafe());
       JS_DupValue(wrappable->ctx(), wrappable->ToQuickJSUnsafe());
     }
     raw_ = p;
   }
 
   mutable T* raw_{nullptr};
+  mutable void* js_object_ptr_{nullptr};
   JSRuntime* runtime_{nullptr};
 };
 

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -4,10 +4,10 @@
  */
 
 #include "script_wrappable.h"
+#include "built_in_string.h"
 #include "core/executing_context.h"
 #include "cppgc/gc_visitor.h"
 #include "foundation/logging.h"
-#include "built_in_string.h"
 
 namespace webf {
 
@@ -267,7 +267,8 @@ void ScriptWrappable::InitializeQuickJSObject() {
 
   // Set .constructor to the constructor function.
   JSValue constructor = context_->contextData()->constructorForType(wrapper_type_info);
-  JS_DefinePropertyValue(ctx_, jsObject_, built_in_string::kconstructor.Impl(), JS_DupValue(ctx_, constructor), JS_PROP_C_W_E);
+  JS_DefinePropertyValue(ctx_, jsObject_, built_in_string::kconstructor.Impl(), JS_DupValue(ctx_, constructor),
+                         JS_PROP_C_W_E);
 
   // Let our instance into inherit prototype methods.
   JSValue prototype = GetExecutingContext()->contextData()->prototypeForType(wrapper_type_info);

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -265,17 +265,17 @@ void ScriptWrappable::InitializeQuickJSObject() {
   jsObject_ = JS_NewObjectClass(ctx_, wrapper_type_info->classId);
   JS_SetOpaque(jsObject_, this);
 
-  // Set .constructor to the constructor function.
-  JSValue constructor = context_->contextData()->constructorForType(wrapper_type_info);
-  JS_DefinePropertyValue(ctx_, jsObject_, built_in_string::kconstructor.Impl(), JS_DupValue(ctx_, constructor),
-                         JS_PROP_C_W_E);
-
   // Print className for toString.
-  JS_DefinePropertyValue(ctx_, jsObject_, JS_ATOM_Symbol_toStringTag, JS_NewString(ctx_, wrapper_type_info->className), JS_PROP_C_W_E);
+  JS_DefinePropertyValue(ctx_, jsObject_, JS_ATOM_Symbol_toStringTag, JS_NewString(ctx_, wrapper_type_info->className), JS_PROP_NORMAL);
 
   // Let our instance into inherit prototype methods.
   JSValue prototype = GetExecutingContext()->contextData()->prototypeForType(wrapper_type_info);
   JS_SetPrototype(ctx_, jsObject_, prototype);
+
+  // Set .constructor to the constructor function.
+  JSValue constructor = context_->contextData()->constructorForType(wrapper_type_info);
+  JS_DefinePropertyValue(ctx_, prototype, built_in_string::kconstructor.Impl(), JS_DupValue(ctx_, constructor),
+                         JS_PROP_NORMAL);
 }
 
 void ScriptWrappable::KeepAlive() {

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -266,7 +266,8 @@ void ScriptWrappable::InitializeQuickJSObject() {
   JS_SetOpaque(jsObject_, this);
 
   // Print className for toString.
-  JS_DefinePropertyValue(ctx_, jsObject_, JS_ATOM_Symbol_toStringTag, JS_NewString(ctx_, wrapper_type_info->className), JS_PROP_NORMAL);
+  JS_DefinePropertyValue(ctx_, jsObject_, JS_ATOM_Symbol_toStringTag, JS_NewString(ctx_, wrapper_type_info->className),
+                         JS_PROP_NORMAL);
 
   // Let our instance into inherit prototype methods.
   JSValue prototype = GetExecutingContext()->contextData()->prototypeForType(wrapper_type_info);

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -270,6 +270,9 @@ void ScriptWrappable::InitializeQuickJSObject() {
   JS_DefinePropertyValue(ctx_, jsObject_, built_in_string::kconstructor.Impl(), JS_DupValue(ctx_, constructor),
                          JS_PROP_C_W_E);
 
+  // Print className for toString.
+  JS_DefinePropertyValue(ctx_, jsObject_, JS_ATOM_Symbol_toStringTag, JS_NewString(ctx_, wrapper_type_info->className), JS_PROP_C_W_E);
+
   // Let our instance into inherit prototype methods.
   JSValue prototype = GetExecutingContext()->contextData()->prototypeForType(wrapper_type_info);
   JS_SetPrototype(ctx_, jsObject_, prototype);

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -6,6 +6,8 @@
 #include "script_wrappable.h"
 #include "core/executing_context.h"
 #include "cppgc/gc_visitor.h"
+#include "foundation/logging.h"
+#include "built_in_string.h"
 
 namespace webf {
 
@@ -262,6 +264,10 @@ void ScriptWrappable::InitializeQuickJSObject() {
   /// triggered.
   jsObject_ = JS_NewObjectClass(ctx_, wrapper_type_info->classId);
   JS_SetOpaque(jsObject_, this);
+
+  // Set .constructor to the constructor function.
+  JSValue constructor = context_->contextData()->constructorForType(wrapper_type_info);
+  JS_DefinePropertyValue(ctx_, jsObject_, built_in_string::kconstructor.Impl(), JS_DupValue(ctx_, constructor), JS_PROP_C_W_E);
 
   // Let our instance into inherit prototype methods.
   JSValue prototype = GetExecutingContext()->contextData()->prototypeForType(wrapper_type_info);

--- a/bridge/bindings/qjs/script_wrappable.cc
+++ b/bridge/bindings/qjs/script_wrappable.cc
@@ -265,18 +265,9 @@ void ScriptWrappable::InitializeQuickJSObject() {
   jsObject_ = JS_NewObjectClass(ctx_, wrapper_type_info->classId);
   JS_SetOpaque(jsObject_, this);
 
-  // Print className for toString.
-  JS_DefinePropertyValue(ctx_, jsObject_, JS_ATOM_Symbol_toStringTag, JS_NewString(ctx_, wrapper_type_info->className),
-                         JS_PROP_NORMAL);
-
   // Let our instance into inherit prototype methods.
   JSValue prototype = GetExecutingContext()->contextData()->prototypeForType(wrapper_type_info);
   JS_SetPrototype(ctx_, jsObject_, prototype);
-
-  // Set .constructor to the constructor function.
-  JSValue constructor = context_->contextData()->constructorForType(wrapper_type_info);
-  JS_DefinePropertyValue(ctx_, prototype, built_in_string::kconstructor.Impl(), JS_DupValue(ctx_, constructor),
-                         JS_PROP_NORMAL);
 }
 
 void ScriptWrappable::KeepAlive() {

--- a/bridge/core/executing_context_data.cc
+++ b/bridge/core/executing_context_data.cc
@@ -3,8 +3,8 @@
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
 #include "executing_context_data.h"
-#include "executing_context.h"
 #include "built_in_string.h"
+#include "executing_context.h"
 
 namespace webf {
 

--- a/bridge/core/executing_context_data.cc
+++ b/bridge/core/executing_context_data.cc
@@ -4,6 +4,7 @@
  */
 #include "executing_context_data.h"
 #include "executing_context.h"
+#include "built_in_string.h"
 
 namespace webf {
 
@@ -54,6 +55,11 @@ JSValue ExecutionContextData::constructorForIdSlowCase(const WrapperTypeInfo* ty
   JSAtom prototypeKey = JS_NewAtom(ctx, "prototype");
   JS_DefinePropertyValue(ctx, classObject, prototypeKey, prototypeObject, JS_PROP_C_W_E);
   JS_FreeAtom(ctx, prototypeKey);
+
+  JS_DefinePropertyValue(ctx, prototypeObject, built_in_string::kconstructor.Impl(), JS_DupValue(ctx, classObject),
+                         JS_PROP_NORMAL);
+  JS_DefinePropertyValue(ctx, prototypeObject, JS_ATOM_Symbol_toStringTag, JS_NewString(ctx, type->className),
+                         JS_PROP_NORMAL);
 
   // Inherit to parentClass.
   if (type->parent_class != nullptr) {

--- a/bridge/core/executing_context_test.cc
+++ b/bridge/core/executing_context_test.cc
@@ -108,7 +108,7 @@ TEST(Context, unrejectPromiseWillTriggerUnhandledRejectionEvent) {
   };
   auto env = TEST_init(errorHandler);
   static int logIndex = 0;
-  static std::string logs[] = {"unhandled event {constructor: ƒ (), promise: Promise {...}, reason: Error {...}} true"};
+  static std::string logs[] = {"unhandled event PromiseRejectionEvent {promise: Promise {...}, reason: Error {...}} true"};
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
     EXPECT_STREQ(logs[logIndex++].c_str(), message.c_str());

--- a/bridge/core/executing_context_test.cc
+++ b/bridge/core/executing_context_test.cc
@@ -108,7 +108,7 @@ TEST(Context, unrejectPromiseWillTriggerUnhandledRejectionEvent) {
   };
   auto env = TEST_init(errorHandler);
   static int logIndex = 0;
-  static std::string logs[] = {"unhandled event {promise: Promise {...}, reason: Error {...}} true"};
+  static std::string logs[] = {"unhandled event {constructor: ƒ (), promise: Promise {...}, reason: Error {...}} true"};
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
     EXPECT_STREQ(logs[logIndex++].c_str(), message.c_str());

--- a/bridge/core/executing_context_test.cc
+++ b/bridge/core/executing_context_test.cc
@@ -108,7 +108,8 @@ TEST(Context, unrejectPromiseWillTriggerUnhandledRejectionEvent) {
   };
   auto env = TEST_init(errorHandler);
   static int logIndex = 0;
-  static std::string logs[] = {"unhandled event PromiseRejectionEvent {promise: Promise {...}, reason: Error {...}} true"};
+  static std::string logs[] = {
+      "unhandled event PromiseRejectionEvent {promise: Promise {...}, reason: Error {...}} true"};
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
     EXPECT_STREQ(logs[logIndex++].c_str(), message.c_str());

--- a/bridge/core/html/custom/widget_element_test.cc
+++ b/bridge/core/html/custom/widget_element_test.cc
@@ -34,7 +34,7 @@ TEST(WidgetElement, getPropertyWithSymbolToStringTag) {
   bool static errorCalled = false;
   bool static logCalled = false;
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
-    EXPECT_STREQ(message.c_str(), "FLUTTER-CHECKBOX");
+    EXPECT_STREQ(message.c_str(), "WidgetElement");
     logCalled = true;
   };
   auto env = TEST_init([](int32_t contextId, const char* errmsg) {

--- a/bridge/core/timing/performance_test.cc
+++ b/bridge/core/timing/performance_test.cc
@@ -69,7 +69,7 @@ TEST(Performance, mark) {
   bool static logCalled = false;
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
-    EXPECT_STREQ(message.c_str(), "{constructor: ƒ (), detail: null}");
+    EXPECT_STREQ(message.c_str(), "PerformanceMark {detail: null}");
   };
   auto env = TEST_init([](int32_t contextId, const char* errmsg) {
     WEBF_LOG(VERBOSE) << errmsg;
@@ -90,7 +90,7 @@ TEST(Performance, markWithDetail) {
   bool static logCalled = false;
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
-    EXPECT_STREQ(message.c_str(), "{constructor: ƒ (), detail: {...}}");
+    EXPECT_STREQ(message.c_str(), "PerformanceMark {detail: {...}}");
   };
   auto env = TEST_init([](int32_t contextId, const char* errmsg) {
     WEBF_LOG(VERBOSE) << errmsg;
@@ -111,7 +111,7 @@ TEST(Performance, markWithName) {
   bool static logCalled = false;
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
-    EXPECT_STREQ(message.c_str(), "[{...}, {...}]");
+    EXPECT_STREQ(message.c_str(), "[PerformanceMark {...}, PerformanceMark {...}]");
   };
   auto env = TEST_init([](int32_t contextId, const char* errmsg) {
     WEBF_LOG(VERBOSE) << errmsg;
@@ -158,7 +158,7 @@ TEST(Performance, clearMarksByName) {
   bool static logCalled = false;
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
-    EXPECT_STREQ(message.c_str(), "[{...}]");
+    EXPECT_STREQ(message.c_str(), "[PerformanceMark {...}]");
   };
   auto env = TEST_init([](int32_t contextId, const char* errmsg) {
     WEBF_LOG(VERBOSE) << errmsg;

--- a/bridge/core/timing/performance_test.cc
+++ b/bridge/core/timing/performance_test.cc
@@ -69,7 +69,7 @@ TEST(Performance, mark) {
   bool static logCalled = false;
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
-    EXPECT_STREQ(message.c_str(), "{detail: null}");
+    EXPECT_STREQ(message.c_str(), "{constructor: ƒ (), detail: null}");
   };
   auto env = TEST_init([](int32_t contextId, const char* errmsg) {
     WEBF_LOG(VERBOSE) << errmsg;
@@ -90,7 +90,7 @@ TEST(Performance, markWithDetail) {
   bool static logCalled = false;
   webf::WebFPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
-    EXPECT_STREQ(message.c_str(), "{detail: {...}}");
+    EXPECT_STREQ(message.c_str(), "{constructor: ƒ (), detail: {...}}");
   };
   auto env = TEST_init([](int32_t contextId, const char* errmsg) {
     WEBF_LOG(VERBOSE) << errmsg;

--- a/bridge/polyfill/src/dom-exception.ts
+++ b/bridge/polyfill/src/dom-exception.ts
@@ -1,0 +1,12 @@
+
+// @ts-ignore
+export class DOMException extends Error {
+  private message: string;
+  private name: string;
+
+  constructor(message = '', name = 'Error') {
+    super();
+    this.name = name;
+    this.message = message;
+  }
+}

--- a/bridge/polyfill/src/index.ts
+++ b/bridge/polyfill/src/index.ts
@@ -15,6 +15,7 @@ import { asyncStorage } from './async-storage';
 import { URLSearchParams } from './url-search-params';
 import { localStorage } from './local-storage';
 import { sessionStorage } from './session-storage';
+import { DOMException } from './dom-exception';
 import { Storage } from './storage';
 import { URL } from './url';
 import { webf } from './webf';
@@ -34,6 +35,7 @@ defineGlobalProperty('localStorage', localStorage);
 defineGlobalProperty('sessionStorage', sessionStorage);
 defineGlobalProperty('Storage', Storage);
 defineGlobalProperty('URLSearchParams', URLSearchParams);
+defineGlobalProperty('DOMException', DOMException);
 defineGlobalProperty('URL', URL);
 defineGlobalProperty('webf', webf);
 

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -30,8 +30,8 @@
     "qs": "^6.11.0",
     "stylesheet-loader": "^0.8.5",
     "typescript": "^3.8.3",
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.12",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^4.10.0",
     "ws": "^7.3.0"
   },
   "dependencies": {

--- a/integration_tests/specs/dom/nodes/element.ts
+++ b/integration_tests/specs/dom/nodes/element.ts
@@ -147,4 +147,14 @@ describe('DOM Element API', () => {
     document.body.appendChild(el);
     expect(el.matches('.a1')).toBeTrue();
   });
+
+  it('should have constructor property for DOM elements', () => {
+    const div = document.createElement('div');
+    expect(div.constructor.prototype.addEventListener).toEqual(div.addEventListener);
+
+    function isObject(o) {
+      return typeof o === 'object' && o !== null && o.constructor && o.constructor === Object;
+    }
+    expect(isObject(div)).toBe(false);
+  })
 });

--- a/integration_tests/specs/dom/nodes/element.ts
+++ b/integration_tests/specs/dom/nodes/element.ts
@@ -156,5 +156,14 @@ describe('DOM Element API', () => {
       return typeof o === 'object' && o !== null && o.constructor && o.constructor === Object;
     }
     expect(isObject(div)).toBe(false);
-  })
+  });
+
+  it('should have className for DOM elements', () => {
+    function isObject(o) {
+      return typeof o === "object" && o !== null && o.constructor && Object.prototype.toString.call(o).slice(8, -1) === "Object";
+    }
+    const div = document.createElement('div');
+    expect(isObject(div)).toBe(false);
+    expect(Object.prototype.toString.call(div)).toBe('[object HTMLDivElement]');
+  });
 });

--- a/webf/lib/src/bridge/from_native.dart
+++ b/webf/lib/src/bridge/from_native.dart
@@ -104,11 +104,12 @@ dynamic invokeModule(Pointer<Void> callbackContext, int contextId, String module
           callbackResult = callback(callbackContext, contextId, nullptr, dataPtr);
           malloc.free(dataPtr);
         }
-        if (isEnabledLog) {
-          print('Invoke module callback from(name: $moduleName method: $method, params: $params) return: ${fromNativeValue(callbackResult)}');
-        }
 
         var returnValue = fromNativeValue(callbackResult);
+        if (isEnabledLog) {
+          print('Invoke module callback from(name: $moduleName method: $method, params: $params) return: $returnValue');
+        }
+
         malloc.free(callbackResult);
         completer.complete(returnValue);
       });


### PR DESCRIPTION
The `constructor` property on DOM elements should point to the constructor function of DOM elements.