### PR TITLE
fix: try to parse base64 encoded font.

### DIFF
--- a/webf/lib/src/css/font_face.dart
+++ b/webf/lib/src/css/font_face.dart
@@ -59,10 +59,12 @@ class CSSFontFace {
             String tmp_content = tmp_src.split(';').last;
             if (tmp_content.startsWith('base64')) {
               String base64 = tmp_src.split(',').last;
-              Uint8List decoded = base64Decode(base64);
-              if (decoded.isNotEmpty) {
-                fonts.add(_Font.content(decoded));
-              }
+              try {
+                Uint8List decoded = base64Decode(base64);
+                if (decoded.isNotEmpty) {
+                  fonts.add(_Font.content(decoded));
+                }
+              } catch(e) {}
             }
 
           } else {


### PR DESCRIPTION
The base64-encoded content of font-face may cause a parse error. This error should be caught if the input is incorrect.

![vNHEXeZvGw](https://github.com/openwebf/webf/assets/4409743/e9350855-ab66-464c-8c00-1de39496e079)
