### PR TITLE
fix: Read `ANDROID_SDK_HOME` before implying to platform defaults

### DIFF
--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -633,7 +633,7 @@ task('build-android-webf-lib', (done) => {
     ndkDir = path.join(androidHome, 'ndk', ndkVersion);
 
     if (!fs.existsSync(ndkDir)) {
-      throw new Error('Android NDK version (22.1.7171670) not installed.');
+      throw new Error('Android NDK version (${ndkVersion}) not installed.');
     }
   }
 

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -613,15 +613,16 @@ task('build-window-webf-lib', (done) => {
 });
 
 task('build-android-webf-lib', (done) => {
-  let androidHome;
-
   let ndkDir = '';
 
   // If ANDROID_NDK_HOME env defined, use it.
   if (process.env.ANDROID_NDK_HOME) {
     ndkDir = process.env.ANDROID_NDK_HOME;
   } else {
-    if (platform == 'win32') {
+    let androidHome;
+    if (process.env.ANDROID_SDK_HOME) {
+      androidHome = process.env.ANDROID_SDK_HOME;
+    } else if (platform == 'win32') {
       androidHome = path.join(process.env.LOCALAPPDATA, 'Android\\Sdk');
     } else if (platform == 'darwin') {
       androidHome = path.join(process.env.HOME, 'Library/Android/sdk')


### PR DESCRIPTION
Previously, when `ANDROID_NDK_HOME` is not configured, the SDK root will be implied to platform default, rather than checking whether `ANDROID_SDK_HOME` is set. The PR fix that.