### PR TITLE
Losen `intl` dependency constraint

### DIFF
--- a/webf/pubspec.yaml
+++ b/webf/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   path: ^1.8.1 # Pure dart module.
   meta: ^1.7.0 # Pure dart module.
   ffi: ^2.0.1 # Pure dart module.
-  intl: ^0.18.1 #Pure dart module.
+  intl: '>=0.17.0 <1.0.0' # Pure dart module.
   hive: ^2.2.3
   characters: ^1.2.0
   collection: ^1.16.0

--- a/webf/pubspec.yaml
+++ b/webf/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.15.0-beta.1+1
 homepage: https://openwebf.com
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=2.18.0 <4.0.0"
   flutter: ">=3.10.0"
 
 dependencies:

--- a/webf/pubspec.yaml
+++ b/webf/pubspec.yaml
@@ -4,16 +4,17 @@ version: 0.15.0-beta.1+1
 homepage: https://openwebf.com
 
 environment:
-  sdk: ">=2.17.5 <4.0.0"
-  flutter: ">=3.0.5"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  intl: ^0.18.0 # Pure dart module. DO NOT MODIFY UNLESS FLUTTER SDK UPDATED.
+
   path: ^1.8.1 # Pure dart module.
   meta: ^1.7.0 # Pure dart module.
   ffi: ^2.0.1 # Pure dart module.
-  intl: '>=0.17.0 <1.0.0' # Pure dart module.
   hive: ^2.2.3
   characters: ^1.2.0
   collection: ^1.16.0
@@ -32,15 +33,6 @@ dev_dependencies:
   lints: ^2.1.1
 
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' and Android 'package' identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
-  #
-  # NOTE: This new plugin description format is not supported on Flutter's
-  # stable channel as of 1.9.1. A plugin published using this format will not
-  # work for most clients until the next major stable release.
-  # However, it is required in order to declare macOS support.
   plugin:
     platforms:
       android:


### PR DESCRIPTION
- `intl` is relatively stable but critical for SDK packages to depend on. If we depend on `^0.18.1`, `flutter_localizations` will be failed to resolve from the Flutter SDK.
- Bumping Flutter SDK constraints too to avoid accidently referencing from an older SDK.