### PR TITLE
fix: fix event not responding when multiple flutter engine created.

### DIFF
--- a/bridge/core/executing_context.cc
+++ b/bridge/core/executing_context.cc
@@ -45,6 +45,7 @@ ExecutingContext::ExecutingContext(DartIsolateContext* dart_isolate_context,
   //  #endif
 
   // @FIXME: maybe contextId will larger than MAX_JS_CONTEXT
+  assert_m(valid_contexts[contextId] != true, "Conflict context found!");
   valid_contexts[contextId] = true;
   if (contextId > running_context_list)
     running_context_list = contextId;

--- a/bridge/include/webf_bridge.h
+++ b/bridge/include/webf_bridge.h
@@ -36,6 +36,10 @@ WEBF_EXPORT_C
 void* initDartIsolateContext(uint64_t* dart_methods, int32_t dart_methods_len);
 WEBF_EXPORT_C
 void* allocateNewPage(void* dart_isolate_context, int32_t targetContextId);
+
+WEBF_EXPORT_C
+int64_t newPageId();
+
 WEBF_EXPORT_C
 void disposePage(void* dart_isolate_context, void* page);
 WEBF_EXPORT_C

--- a/bridge/webf_bridge.cc
+++ b/bridge/webf_bridge.cc
@@ -37,6 +37,8 @@
 #define SYSTEM_NAME "unknown"
 #endif
 
+static std::atomic<int64_t> unique_page_id{0};
+
 void* initDartIsolateContext(uint64_t* dart_methods, int32_t dart_methods_len) {
   void* ptr = new webf::DartIsolateContext(dart_methods, dart_methods_len);
   return ptr;
@@ -49,6 +51,10 @@ void* allocateNewPage(void* dart_isolate_context, int32_t targetContextId) {
   void* ptr = page.get();
   ((webf::DartIsolateContext*)dart_isolate_context)->AddNewPage(std::move(page));
   return ptr;
+}
+
+int64_t newPageId() {
+  return unique_page_id++;
 }
 
 void disposePage(void* dart_isolate_context, void* page_) {

--- a/webf/lib/src/bridge/bridge.dart
+++ b/webf/lib/src/bridge/bridge.dart
@@ -10,12 +10,6 @@ import 'binding.dart';
 import 'from_native.dart';
 import 'to_native.dart';
 
-int _contextId = 0;
-
-int newContextId() {
-  return ++_contextId;
-}
-
 class DartContext {
   DartContext() : pointer = initDartIsolateContext(makeDartMethodsData()) {
     initDartDynamicLinking();
@@ -31,7 +25,7 @@ int initBridge(WebFViewController view) {
   // Setup binding bridge.
   BindingBridge.setup();
 
-  int pageId = newContextId();
+  int pageId = newPageId();
   allocateNewPage(pageId);
 
   return pageId;

--- a/webf/lib/src/bridge/to_native.dart
+++ b/webf/lib/src/bridge/to_native.dart
@@ -237,6 +237,15 @@ void disposePage(int contextId) {
   _allocatedPages.remove(contextId);
 }
 
+typedef NativeNewPageId = Int64 Function();
+typedef DartNewPageId = int Function();
+
+final DartNewPageId _newPageId = WebFDynamicLibrary.ref.lookup<NativeFunction<NativeNewPageId>>('newPageId').asFunction();
+
+int newPageId() {
+  return _newPageId();
+}
+
 typedef NativeAllocateNewPage = Pointer<Void> Function(Pointer<Void>, Int32);
 typedef DartAllocateNewPage = Pointer<Void> Function(Pointer<Void>, int);
 


### PR DESCRIPTION
When multiple Flutter engines are created and the top one pops up, the remaining web page may become unresponsive, leading to the following errors:

<img width="1357" alt="image" src="https://github.com/openwebf/webf/assets/4409743/9e1e765d-d0f0-46a7-b415-7b3a9e2add74">
