### PR TITLE
Fix: should protect DartWireContext before JS Object been finalized.

### DIFF
--- a/bridge/core/dart_isolate_context.cc
+++ b/bridge/core/dart_isolate_context.cc
@@ -28,6 +28,10 @@ void DeleteDartWire(DartWireContext* wire) {
   delete wire;
 }
 
+DartWireContext::~DartWireContext() {
+  Dart_DeletePersistentHandle_DL(dart_handle);
+}
+
 static void ClearUpWires() {
   for (auto& wire : alive_wires) {
     delete wire;

--- a/bridge/core/dart_isolate_context.h
+++ b/bridge/core/dart_isolate_context.h
@@ -6,6 +6,7 @@
 #define WEBF_DART_CONTEXT_H_
 
 #include <set>
+#include "include/dart_api.h"
 #include "bindings/qjs/script_value.h"
 #include "dart_context_data.h"
 #include "dart_methods.h"
@@ -17,6 +18,8 @@ class DartIsolateContext;
 
 struct DartWireContext {
   ScriptValue jsObject;
+  Dart_Handle dart_handle;
+  ~DartWireContext();
 };
 
 void InitializeBuiltInStrings(JSContext* ctx);

--- a/bridge/core/dart_isolate_context.h
+++ b/bridge/core/dart_isolate_context.h
@@ -6,10 +6,10 @@
 #define WEBF_DART_CONTEXT_H_
 
 #include <set>
-#include "include/dart_api.h"
 #include "bindings/qjs/script_value.h"
 #include "dart_context_data.h"
 #include "dart_methods.h"
+#include "include/dart_api.h"
 
 namespace webf {
 

--- a/bridge/core/dom/events/event_target.cc
+++ b/bridge/core/dom/events/event_target.cc
@@ -390,6 +390,7 @@ NativeValue EventTarget::HandleDispatchEventFromDart(int32_t argc, const NativeV
   WatchDartWire(wire);
   Dart_NewFinalizableHandle_DL(dart_object, reinterpret_cast<void*>(wire), sizeof(DartWireContext),
                                dart_object_finalize_callback);
+  wire->dart_handle = Dart_NewPersistentHandle_DL(dart_object);
 
   if (exception_state.HasException()) {
     JSValue error = JS_GetException(ctx());


### PR DESCRIPTION
There is a potential scenario where a Dart event could be finalized before the corresponding JS event objects, leading to a use-after-free crash when a user tries to access this JS object.

Fixed #456

