### PR TITLE
fix: fix crash when reload pages.

### DIFF
--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -150,7 +150,6 @@ class WebFViewController implements WidgetsBindingObserver {
   WebFViewController(this._viewportWidth, this._viewportHeight,
       {this.background,
       this.enableDebug = false,
-      int? contextId,
       required this.rootController,
       this.navigationDelegate,
       this.gestureListener,
@@ -162,7 +161,7 @@ class WebFViewController implements WidgetsBindingObserver {
       debugPaintSizeEnabled = true;
     }
     BindingBridge.setup();
-    _contextId = contextId ?? initBridge(this);
+    _contextId = initBridge(this);
 
     if (originalViewport != null) {
       viewport = originalViewport;
@@ -898,18 +897,24 @@ class WebFController {
       // RenderViewportBox will not disposed when reload, just remove all children and clean all resources.
       _view.viewport.reload();
 
-      allocateNewPage(_view.contextId);
+      int oldId = _view.contextId;
 
       _view = WebFViewController(view.viewportWidth, view.viewportHeight,
           background: _view.background,
           enableDebug: _view.enableDebug,
-          contextId: _view.contextId,
           rootController: this,
           navigationDelegate: _view.navigationDelegate,
           gestureListener: _view.gestureListener,
           originalViewport: _view.viewport);
 
       _module = WebFModuleController(this, _view.contextId);
+
+      // Reconnect the new contextId to the Controller
+      _controllerMap.remove(oldId);
+      _controllerMap[_view.contextId] = this;
+      if (name != null) {
+        _nameIdMap[name!] = _view.contextId;
+      }
 
       completer.complete();
     });


### PR DESCRIPTION
Fix crash when page reload multiple times with the follow crash stacks:

```
Thread 1 Crashed:: io.flutter.ui
0   libwebf.dylib                 	       0x102ebf3a0 webf::ExecutingContext::dartIsolateContext() const + 0 (executing_context.h:121) [inlined]
1   libwebf.dylib                 	       0x102ebf3a0 webf::UICommandBuffer::addCommand(webf::UICommandItem const&, bool) + 20 (ui_command_buffer.cc:31)
2   libwebf.dylib                 	       0x102ebf380 webf::UICommandBuffer::addCommand(webf::UICommand, std::__1::unique_ptr<webf::SharedNativeString, std::__1::default_delete<webf::SharedNativeString>>&&, void*, void*, bool) + 64 (ui_command_buffer.cc:27)
3   libwebf.dylib                 	       0x102ee5d8c webf::BindingObject::~BindingObject() + 100 (binding_object.cc:42)
4   libwebf.dylib                 	       0x102ee4468 webf::EventTarget::~EventTarget() + 12 (event_target.cc:66)
5   libwebf.dylib                 	       0x102ee8948 webf::Node::~Node() + 244 (node.cc:584)
6   libwebf.dylib                 	       0x102ee9700 webf::CharacterData::~CharacterData() + 36 (character_data.h:15) [inlined]
7   libwebf.dylib                 	       0x102ee9700 webf::Text::~Text() + 36 (text.h:13) [inlined]
8   libwebf.dylib                 	       0x102ee9700 webf::Text::~Text() + 36 (text.h:13) [inlined]
9   libwebf.dylib                 	       0x102ee9700 webf::Text::~Text() + 52 (text.h:13)
10  libwebf.dylib                 	       0x102ec285c webf::HandleJSObjectFinalized(JSRuntime*, JSValue) + 100 (script_wrappable.cc:52)
11  libquickjs.dylib              	       0x102994958 free_object + 196 (gc.c:403)
12  libquickjs.dylib              	       0x102995aa8 free_gc_object + 16 (gc.c:422) [inlined]
13  libquickjs.dylib              	       0x102995aa8 gc_free_cycles + 132 (gc.c:775)
14  libquickjs.dylib              	       0x102995bc4 JS_RunGC + 184 (gc.c:803)
15  libwebf.dylib                 	       0x102ecc28c webf::ScriptState::~ScriptState() + 32 (script_state.cc:31) [inlined]
16  libwebf.dylib                 	       0x102ecc28c webf::ScriptState::~ScriptState() + 52 (script_state.cc:25)
17  libwebf.dylib                 	       0x102eca4cc webf::ExecutingContext::~ExecutingContext() + 664 (executing_context.cc:111)
18  libwebf.dylib                 	       0x102eca7c0 webf::ExecutingContext::~ExecutingContext() + 12 (executing_context.cc:93)
19  libwebf.dylib                 	       0x102eccb98 webf::WebFPage::~WebFPage() + 28 (page.cc:150) [inlined]
20  libwebf.dylib                 	       0x102eccb98 webf::WebFPage::~WebFPage() + 44 (page.cc:144)

```