### PR TITLE
✨ Introduce `resizeToAvoidBottomInsets`

### DIFF
--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -624,18 +624,21 @@ class WebFViewController implements WidgetsBindingObserver {
   void didChangeLocales(List<Locale>? locales) {
   }
 
-  ui.ViewPadding? _prevViewInsets;
   static double FOCUS_VIEWINSET_BOTTOM_OVERALL = 32;
 
   @override
   void didChangeMetrics() {
-    double bottomInset = rootController.ownerFlutterView.viewInsets.bottom / rootController.ownerFlutterView.devicePixelRatio;
-    _prevViewInsets ??= rootController.ownerFlutterView.viewInsets;
+    final ownerView = rootController.ownerFlutterView;
 
-    if (_prevViewInsets!.bottom > rootController.ownerFlutterView.viewInsets.bottom) {
-      // Hide keyboard
-      viewport.bottomInset = bottomInset;
+    final bool resizeToAvoidBottomInsets = rootController.resizeToAvoidBottomInsets;
+    final double bottomInsets;
+    if (resizeToAvoidBottomInsets) {
+      bottomInsets = ownerView.viewInsets.bottom / ownerView.devicePixelRatio;
     } else {
+      bottomInsets = 0;
+    }
+
+    if (resizeToAvoidBottomInsets) {
       bool shouldScrollByToCenter = false;
       Element? focusedElement = document.focusedElement;
       double scrollOffset = 0;
@@ -644,20 +647,19 @@ class WebFViewController implements WidgetsBindingObserver {
         if (renderer != null && renderer.attached && renderer.hasSize) {
           Offset focusOffset = renderer.localToGlobal(Offset.zero);
           // FOCUS_VIEWINSET_BOTTOM_OVERALL to meet border case.
-          if (focusOffset.dy > viewportHeight - bottomInset - FOCUS_VIEWINSET_BOTTOM_OVERALL) {
+          if (focusOffset.dy > viewportHeight - bottomInsets - FOCUS_VIEWINSET_BOTTOM_OVERALL) {
             shouldScrollByToCenter = true;
             scrollOffset =
-                focusOffset.dy - (viewportHeight - bottomInset) + renderer.size.height + FOCUS_VIEWINSET_BOTTOM_OVERALL;
+                focusOffset.dy - (viewportHeight - bottomInsets) + renderer.size.height + FOCUS_VIEWINSET_BOTTOM_OVERALL;
           }
         }
       }
       // Show keyboard
-      viewport.bottomInset = bottomInset;
       if (shouldScrollByToCenter) {
         window.scrollBy(0, scrollOffset, true);
       }
     }
-    _prevViewInsets = rootController.ownerFlutterView.viewInsets;
+    viewport.bottomInset = bottomInsets;
   }
 
   @override
@@ -769,6 +771,7 @@ class WebFController {
   final List<Cookie>? initialCookies;
 
   final ui.FlutterView ownerFlutterView;
+  bool resizeToAvoidBottomInsets;
 
   String? _name;
   String? get name => _name;
@@ -810,6 +813,7 @@ class WebFController {
     this.uriParser,
     this.initialCookies,
     required this.ownerFlutterView,
+    this.resizeToAvoidBottomInsets = true,
   })  : _name = name,
         _entrypoint = entrypoint,
         _gestureListener = gestureListener {

--- a/webf/lib/src/widget/webf.dart
+++ b/webf/lib/src/widget/webf.dart
@@ -72,9 +72,9 @@ class WebF extends StatefulWidget {
   /// whose height is defined by the ambient [FlutterView]'s
   /// [FlutterView.viewInsets] `bottom` property.
   ///
-  /// For example, if there is an onscreen keyboard displayed above the
-  /// scaffold, the body can be resized to avoid overlapping the keyboard, which
-  /// prevents widgets inside the body from being obscured by the keyboard.
+  /// For example, if there is an onscreen keyboard displayed above the widget,
+  /// the view can be resized to avoid overlapping the keyboard, which prevents
+  /// widgets inside the view from being obscured by the keyboard.
   ///
   /// Defaults to true.
   final bool resizeToAvoidBottomInsets;

--- a/webf/lib/src/widget/webf.dart
+++ b/webf/lib/src/widget/webf.dart
@@ -68,6 +68,17 @@ class WebF extends StatefulWidget {
   /// The initial cookies to set.
   final List<Cookie>? initialCookies;
 
+  /// If true the content should size itself to avoid the onscreen keyboard
+  /// whose height is defined by the ambient [FlutterView]'s
+  /// [FlutterView.viewInsets] `bottom` property.
+  ///
+  /// For example, if there is an onscreen keyboard displayed above the
+  /// scaffold, the body can be resized to avoid overlapping the keyboard, which
+  /// prevents widgets inside the body from being obscured by the keyboard.
+  ///
+  /// Defaults to true.
+  final bool resizeToAvoidBottomInsets;
+
   WebFController? get controller {
     return WebFController.getControllerOfName(shortHash(this));
   }
@@ -130,7 +141,8 @@ class WebF extends StatefulWidget {
       // Callback functions when loading Javascript scripts failed.
       this.onLoadError,
       this.animationController,
-      this.onJSError})
+      this.onJSError,
+      this.resizeToAvoidBottomInsets = true})
       : super(key: key);
 
   @override
@@ -221,6 +233,7 @@ class WebFState extends State<WebF> with RouteAware {
           onCustomElementAttached: onCustomElementWidgetAdd,
           onCustomElementDetached: onCustomElementWidgetRemove,
           children: customElementWidgets.toList(),
+          resizeToAvoidBottomInsets: widget.resizeToAvoidBottomInsets,
         ),
       ),
     );
@@ -231,6 +244,14 @@ class WebFState extends State<WebF> with RouteAware {
     super.didChangeDependencies();
     if (widget.routeObserver != null) {
       widget.routeObserver!.subscribe(this, ModalRoute.of(context)!);
+    }
+  }
+
+  @override
+  void didUpdateWidget(WebF oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.resizeToAvoidBottomInsets != widget.resizeToAvoidBottomInsets) {
+      widget.controller?.resizeToAvoidBottomInsets = widget.resizeToAvoidBottomInsets;
     }
   }
 
@@ -287,6 +308,7 @@ class WebFRootRenderObjectWidget extends MultiChildRenderObjectWidget {
   final OnCustomElementAttached onCustomElementAttached;
   final OnCustomElementDetached onCustomElementDetached;
   final FlutterView currentView;
+  final bool resizeToAvoidBottomInsets;
 
   // Creates a widget that visually hides its child.
   WebFRootRenderObjectWidget(
@@ -296,6 +318,7 @@ class WebFRootRenderObjectWidget extends MultiChildRenderObjectWidget {
     required this.currentView,
     required this.onCustomElementAttached,
     required this.onCustomElementDetached,
+    this.resizeToAvoidBottomInsets = true,
   })  : _webfWidget = widget,
         super(key: key, children: children);
 
@@ -324,7 +347,8 @@ class WebFRootRenderObjectWidget extends MultiChildRenderObjectWidget {
         onCustomElementDetached: onCustomElementDetached,
         initialCookies: _webfWidget.initialCookies,
         uriParser: _webfWidget.uriParser,
-        ownerFlutterView: currentView);
+        ownerFlutterView: currentView,
+        resizeToAvoidBottomInsets: resizeToAvoidBottomInsets);
 
     (context as _WebFRenderObjectElement).controller = controller;
 


### PR DESCRIPTION
(downstream https://github.com/AstroxNetwork/flutter_webf/commit/b3a9a696735165307c021a43aea0ec9b6d37e453)

- Add `resizeToAvoidBottomInsets` to flag for `WebF`, `WebFRootRenderObjectWidget`, and `WebFController`, to determine whether the `WebFViewController` should deal with insets changes.
- Remove the redundant `_prevViewInsets`.