### PR TITLE
fix: fix JavaScript stack overflow error when print Proxy object.

### DIFF
--- a/bridge/core/frame/console.cc
+++ b/bridge/core/frame/console.cc
@@ -2,8 +2,8 @@
  * Copyright (C) 2019-2022 The Kraken authors. All rights reserved.
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
-#include <quickjs/quickjs.h>
 #include "console.h"
+#include <quickjs/quickjs.h>
 #include <sstream>
 #include "built_in_string.h"
 #include "foundation/logging.h"

--- a/bridge/core/frame/console.cc
+++ b/bridge/core/frame/console.cc
@@ -2,6 +2,7 @@
  * Copyright (C) 2019-2022 The Kraken authors. All rights reserved.
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
+#include <quickjs/quickjs.h>
 #include "console.h"
 #include <sstream>
 #include "built_in_string.h"
@@ -25,6 +26,10 @@ void Console::__webf_print__(ExecutingContext* context, const AtomicString& log,
   std::string buffer = log.ToStdString(context->ctx());
   stream << buffer;
   printLog(context, stream, "info", nullptr);
+}
+
+bool Console::__webf_is_proxy__(ExecutingContext* context, const ScriptValue& log, ExceptionState& exception_state) {
+  return JS_IsProxy(log.QJSValue());
 }
 
 }  // namespace webf

--- a/bridge/core/frame/console.d.ts
+++ b/bridge/core/frame/console.d.ts
@@ -1,1 +1,2 @@
 declare const __webf_print__: (log: string, level?: string) => void;
+declare const __webf_is_proxy__: (obj: any) => boolean;

--- a/bridge/core/frame/console.h
+++ b/bridge/core/frame/console.h
@@ -18,6 +18,7 @@ class Console final {
                              const AtomicString& level,
                              ExceptionState& exception);
   static void __webf_print__(ExecutingContext* context, const AtomicString& log, ExceptionState& exception_state);
+  static bool __webf_is_proxy__(ExecutingContext* context, const ScriptValue& log, ExceptionState& exception_state);
 };
 
 }  // namespace webf

--- a/bridge/polyfill/src/bridge.ts
+++ b/bridge/polyfill/src/bridge.ts
@@ -20,3 +20,7 @@ export const webfLocationReload = __webf_location_reload__;
 
 declare const __webf_print__: (log: string, level?: string) => void;
 export const webfPrint = __webf_print__;
+
+declare const __webf_is_proxy__: (obj: any) => boolean;
+
+export const webfIsProxy = __webf_is_proxy__;

--- a/bridge/polyfill/src/console.ts
+++ b/bridge/polyfill/src/console.ts
@@ -4,7 +4,7 @@
 */
 
 // https://console.spec.whatwg.org/
-import { webfPrint } from './bridge';
+import { webfPrint, webfIsProxy } from './bridge';
 
 const SEPARATOR = ' ';
 const INTERPOLATE = /%[sdifoO]/g;
@@ -115,6 +115,10 @@ function inspect(obj: any, within?: boolean): string {
       result += '/';
     }
     return result + '>';
+  }
+
+  if (webfIsProxy(obj)) {
+    return 'Proxy()';
   }
 
   var kind = Object.prototype.toString.call(obj).slice(8, -1);


### PR DESCRIPTION
Fix the stack overflow error in Vue.js app when other error throws.

```
InternalError: stack overflow
    at <anonymous> (http://localhost:8080/js/chunk-vendors.js:1767:34)
    at forEach (native)
    at formatTrace (http://localhost:8080/js/chunk-vendors.js:1768:9)
    at warn (http://localhost:8080/js/chunk-vendors.js:1732:7)
    at <anonymous> (http://localhost:8080/js/chunk-vendors.js:4726:5)
```