### PR TITLE
🐛 Avoid `Hive.init` cause conflicts with box paths

### DIFF
--- a/webf/lib/src/module/local_storage.dart
+++ b/webf/lib/src/module/local_storage.dart
@@ -21,14 +21,14 @@ class LocalStorageModule extends BaseModule {
 
   @override
   Future<void> initialize() async {
-    String tmpPath = await getWebFTemporaryPath();
-    Hive.init(path.join(tmpPath, 'LocalStorage'));
-    String key = getBoxKey(moduleManager!);
+    final key = getBoxKey(moduleManager!);
+    final tmpPath = await getWebFTemporaryPath();
+    final storagePath = path.join(tmpPath, 'LocalStorage');
     try {
-      await Hive.openBox(key);
+      await Hive.openBox(key, path: storagePath);
     } catch (e) {
-      // Try twice to avoid Resource temporarily unavailable.
-      await Hive.openBox(key);
+      // Try again to avoid resources are temporarily unavailable.
+      await Hive.openBox(key, path: storagePath);
     }
   }
 


### PR DESCRIPTION
(downstream https://github.com/AstroxNetwork/flutter_webf/commit/eb95a178cad5395a32f6f899c67943e2716e9867)

`Hive.init` will update the `homePath` of the `HiveImpl`, which will lead to newly opened boxes using the new base path.

https://github.com/isar/hive/blob/470473ffc1ba39f6c90f31ababe0ee63b76b69fe/hive/lib/src/hive_impl.dart#L57

This behavior is undesirable and will cause severe storage issues for users.