### PR TITLE
fix: fix init touchEvent from JS cause crash.

### DIFF
--- a/bridge/core/events/touch_event.cc
+++ b/bridge/core/events/touch_event.cc
@@ -21,7 +21,10 @@ TouchEvent* TouchEvent::Create(ExecutingContext* context,
 }
 
 TouchEvent::TouchEvent(ExecutingContext* context, const AtomicString& type, ExceptionState& exception_state)
-    : UIEvent(context, type, exception_state) {}
+    : UIEvent(context, type, exception_state),
+    changed_touches_(TouchList::Create(context)),
+    touches_(TouchList::Create(context)),
+    target_touches_(TouchList::Create(context)) {}
 
 TouchEvent::TouchEvent(ExecutingContext* context,
                        const AtomicString& type,
@@ -29,12 +32,12 @@ TouchEvent::TouchEvent(ExecutingContext* context,
                        ExceptionState& exception_state)
     : UIEvent(context, type, initializer, exception_state),
       alt_key_(initializer->hasAltKey() && initializer->altKey()),
-      changed_touches_(initializer->hasChangedTouches() ? initializer->changedTouches() : nullptr),
+      changed_touches_(initializer->hasChangedTouches() ? initializer->changedTouches() : TouchList::Create(context)),
       ctrl_key_(initializer->hasCtrlKey() && initializer->ctrlKey()),
       meta_key_(initializer->hasMetaKey() && initializer->metaKey()),
       shift_key_(initializer->hasShiftKey() && initializer->shiftKey()),
-      target_touches_(initializer->hasTargetTouches() ? initializer->targetTouches() : nullptr),
-      touches_(initializer->hasTouches() ? initializer->touches() : nullptr) {}
+      target_touches_(initializer->hasTargetTouches() ? initializer->targetTouches() : TouchList::Create(context)),
+      touches_(initializer->hasTouches() ? initializer->touches() : TouchList::Create(context)) {}
 
 TouchEvent::TouchEvent(ExecutingContext* context, const AtomicString& type, NativeTouchEvent* native_touch_event)
     : UIEvent(context, type, &native_touch_event->native_event),

--- a/bridge/core/events/touch_event.cc
+++ b/bridge/core/events/touch_event.cc
@@ -22,9 +22,9 @@ TouchEvent* TouchEvent::Create(ExecutingContext* context,
 
 TouchEvent::TouchEvent(ExecutingContext* context, const AtomicString& type, ExceptionState& exception_state)
     : UIEvent(context, type, exception_state),
-    changed_touches_(TouchList::Create(context)),
-    touches_(TouchList::Create(context)),
-    target_touches_(TouchList::Create(context)) {}
+      changed_touches_(TouchList::Create(context)),
+      touches_(TouchList::Create(context)),
+      target_touches_(TouchList::Create(context)) {}
 
 TouchEvent::TouchEvent(ExecutingContext* context,
                        const AtomicString& type,

--- a/bridge/core/input/touch_list.cc
+++ b/bridge/core/input/touch_list.cc
@@ -20,9 +20,15 @@ void TouchList::FromNativeTouchList(ExecutingContext* context,
   delete native_touch_list;
 }
 
+TouchList* TouchList::Create(webf::ExecutingContext* context) {
+  return MakeGarbageCollected<TouchList>(context);
+}
+
 TouchList::TouchList(ExecutingContext* context, NativeTouchList* native_touch_list) : ScriptWrappable(context->ctx()) {
   FromNativeTouchList(context, this, native_touch_list);
 }
+
+TouchList::TouchList(webf::ExecutingContext* context): ScriptWrappable(context->ctx()) {}
 
 uint32_t TouchList::length() const {
   return values_.size();

--- a/bridge/core/input/touch_list.cc
+++ b/bridge/core/input/touch_list.cc
@@ -28,7 +28,7 @@ TouchList::TouchList(ExecutingContext* context, NativeTouchList* native_touch_li
   FromNativeTouchList(context, this, native_touch_list);
 }
 
-TouchList::TouchList(webf::ExecutingContext* context): ScriptWrappable(context->ctx()) {}
+TouchList::TouchList(webf::ExecutingContext* context) : ScriptWrappable(context->ctx()) {}
 
 uint32_t TouchList::length() const {
   return values_.size();

--- a/bridge/core/input/touch_list.h
+++ b/bridge/core/input/touch_list.h
@@ -21,10 +21,12 @@ class TouchList : public ScriptWrappable {
  public:
   using ImplType = TouchList*;
 
+  static TouchList* Create(ExecutingContext* context);
   static void FromNativeTouchList(ExecutingContext* context, TouchList* touch_list, NativeTouchList* native_touch_list);
 
   TouchList() = delete;
   explicit TouchList(ExecutingContext* context, NativeTouchList* native_touch_list);
+  explicit TouchList(ExecutingContext* context);
 
   uint32_t length() const;
   Touch* item(uint32_t index, ExceptionState& exception_state) const;

--- a/integration_tests/specs/dom/events/touchEvent.ts
+++ b/integration_tests/specs/dom/events/touchEvent.ts
@@ -234,4 +234,14 @@ describe('TouchEvent', () => {
       await simulatePointMove(12, 12);
     });
   });
+
+  it('should works when initialize TouchEvent from JS', () => {
+    const container = createElement('div', {}, []);
+    document.body.appendChild(container);
+    const touchEvent = new TouchEvent('touchstart');
+    container.dispatchEvent(touchEvent);
+
+    const touchEvent2 = new TouchEvent('touchstart', {});
+    container.dispatchEvent(touchEvent2);
+  })
 });


### PR DESCRIPTION
The following JavaScript code is causing crashes:

![image](https://github.com/openwebf/webf/assets/4409743/f3ccc0ef-4a42-4eaf-872d-11bc25abbfaf)


```javascript
 const container = createElement('div', {}, []);
document.body.appendChild(container);
const touchEvent = new TouchEvent('touchstart');
container.dispatchEvent(touchEvent);

const touchEvent2 = new TouchEvent('touchstart', {});
container.dispatchEvent(touchEvent2);
```