### PR TITLE
fix: text calculate constraints error

### DIFF
--- a/webf/lib/src/css/render_style.dart
+++ b/webf/lib/src/css/render_style.dart
@@ -1623,7 +1623,8 @@ class CSSRenderStyle extends RenderStyle
         bool isGrandParentFlex = grandParentRenderStyle.display == CSSDisplay.flex ||
             grandParentRenderStyle.display == CSSDisplay.inlineFlex;
         bool isHorizontalDirection = CSSFlex.isHorizontalFlexDirection(grandParentRenderStyle.flexDirection);
-        if (isGrandParentFlex && isHorizontalDirection && parentRenderStyle.flexShrink == 0) {
+        if (isGrandParentFlex && isHorizontalDirection && parentRenderStyle.flexShrink == 0 &&
+            parentRenderStyle.contentBoxLogicalWidth == null && parentRenderStyle.maxWidth.value == null) {
           return null;
         }
       }


### PR DESCRIPTION
test code  is like this:
`<!DOCTYPE html>
<html>
<head>
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <style>
      .container2{
        width: 286px;
        overflow: hidden;
        display: flex;
        flex-direction: row;
      }
      .container{  
        flex:1;
        flex-shrink: 0;
        overflow: visible;
        max-height: 260px;
        display: flex;
        flex-direction: column;
      }
      .container3{  
        display: flex;
        flex-direction: column;
      }
      .kl2{
        word-break: break-all;
      }
    </style>
</head>
<body>
    <div class="container3">
        <div class="container2">
            <div class="container">
              <span class="kl2">
                asdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjfasdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjfasdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjfasdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjfasdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjfasdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjfasdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjfasdfasjflasfas;fjlasjfl;asjfl;asjflk;asjflasjfjaskl;fjals;jfl;asjfl;asjflajsfljasl;fjals;jfl;asjdfl;asjfl;asjf
              </span>
            </div>
        </div>
    </div>


</body>
</html>
`