### PR TITLE
fix: add ignoreDeprecations

### DIFF
--- a/bridge/polyfill/package.json
+++ b/bridge/polyfill/package.json
@@ -29,6 +29,6 @@
     "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-terser": "^5.3.0",
     "ts-loader": "^6.2.1",
-    "typescript": "4.8.4"
+    "typescript": "^5.3.2"
   }
 }

--- a/bridge/polyfill/tsconfig.json
+++ b/bridge/polyfill/tsconfig.json
@@ -20,6 +20,7 @@
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "declaration": false
+    "declaration": false,
+    "ignoreDeprecations":  "5.0"
   }
 }

--- a/bridge/scripts/code_generator/package.json
+++ b/bridge/scripts/code_generator/package.json
@@ -15,7 +15,7 @@
     "glob": "^7.1.7",
     "json5": "^2.2.1",
     "lodash": "^4.17.21",
-    "typescript": "4.3.5"
+    "typescript": "^5.3.2"
   },
   "devDependencies": {
     "cross-env": "^7.0.3"

--- a/bridge/scripts/code_generator/tsconfig.json
+++ b/bridge/scripts/code_generator/tsconfig.json
@@ -20,6 +20,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "declaration": false,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "ignoreDeprecations":  "5.0"
   }
 }

--- a/bridge/tsconfig.json
+++ b/bridge/tsconfig.json
@@ -20,6 +20,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "declaration": false,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "ignoreDeprecations":  "5.0"
   }
 }

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -20,6 +20,7 @@
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "declaration": false
+    "declaration": false,
+    "ignoreDeprecations":  "5.0"
   }
 }

--- a/performance_tests/benchmark/tsconfig.json
+++ b/performance_tests/benchmark/tsconfig.json
@@ -27,7 +27,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "rax-app": [".rax/index.ts"]
-    }
+    },
+    "ignoreDeprecations":  "5.0"
   },
   "include": ["src", ".rax"],
   "exclude": ["node_modules", "build", "public"]


### PR DESCRIPTION
Option 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.