### PR TITLE
fix: sliver layout child boundingClientRect offset error

### DIFF
--- a/webf/lib/src/dom/sliver_manager.dart
+++ b/webf/lib/src/dom/sliver_manager.dart
@@ -163,4 +163,20 @@ class RenderSliverRepaintProxy extends RenderProxyBox {
       }
     }
   }
+
+  void applyLayoutTransform(RenderObject child, Matrix4 transform, bool excludeScrollOffset) {
+    assert(child.parent == this);
+    assert(parentData is SliverMultiBoxAdaptorParentData);
+    assert(parent is WebFRenderSliverList);
+
+    SliverConstraints grandParentConstraints = (parent as WebFRenderSliverList).constraints;
+    Offset offset;
+    double? value = (parentData as SliverMultiBoxAdaptorParentData).layoutOffset;
+    if(grandParentConstraints.axisDirection == AxisDirection.right) {
+      offset = Offset(value ?? 0, 0);
+    } else {
+      offset = Offset(0, value ?? 0);
+    }
+    transform.translate(offset.dx, offset.dy);
+  }
 }

--- a/webf/lib/src/rendering/box_model.dart
+++ b/webf/lib/src/rendering/box_model.dart
@@ -53,6 +53,8 @@ Offset getLayoutTransformTo(RenderObject current, RenderObject ancestor, {bool e
     // Apply the layout transform for renderBoxModel and fallback to paint transform for other renderObject type.
     if (parentRenderer is RenderBoxModel) {
       offset += parentRenderer.obtainLayoutTransform(childRenderer, excludeScrollOffset);
+    } else if (parentRenderer is RenderSliverRepaintProxy) {
+      parentRenderer.applyLayoutTransform(childRenderer, transform, excludeScrollOffset);
     } else if (parentRenderer is RenderBox) {
       assert(childRenderer.parent == parentRenderer);
       if (childRenderer.parentData is BoxParentData) {


### PR DESCRIPTION
fix sliver child boundingClientRect() return x、y loss offset.