### PR TITLE
fix: devtool select img element

### DIFF
--- a/webf/lib/src/svg/svg.dart
+++ b/webf/lib/src/svg/svg.dart
@@ -9,7 +9,6 @@ import 'package:webf/dom.dart';
 import 'package:webf/foundation.dart';
 import 'package:webf/svg.dart';
 import 'core/aspect_ratio.dart';
-import 'rendering/root.dart';
 
 const DEFAULT_VIEW_BOX_TOP = 0.0;
 const DEFAULT_VIEW_BOX_LEFT = 0.0;

--- a/webf/lib/src/svg/svg_render_object_builder.dart
+++ b/webf/lib/src/svg/svg_render_object_builder.dart
@@ -8,7 +8,6 @@ import 'package:webf/dom.dart';
 import 'package:webf/painting.dart';
 import 'package:webf/rendering.dart';
 import 'package:webf/src/svg/rendering/container.dart';
-import 'package:webf/src/svg/rendering/root.dart';
 import 'package:webf/svg.dart';
 
 // Those size is get from chrome. I cannot found any specs for that. @XGHeaven
@@ -109,10 +108,14 @@ class SVGRenderBoxBuilder {
         element.renderStyle.height = CSSLengthValue.auto;
         element.renderStyle.width = CSSLengthValue.auto;
       }
+      element.tagName = tagName;
+      element.namespaceURI = SVG_ELEMENT_URI;
       return element.renderBoxModel!;
     }
     print('Unknown SVG element $tagName');
     final element = SVGUnknownElement(null);
+    element.tagName = tagName;
+    element.namespaceURI = SVG_ELEMENT_URI;
     return element.renderBoxModel!;
   }
 

--- a/webf/lib/svg.dart
+++ b/webf/lib/svg.dart
@@ -20,3 +20,5 @@ export 'src/svg/style.dart';
 export 'src/svg/line.dart';
 export 'src/svg/constants.dart';
 export 'src/svg/svg_render_object_builder.dart';
+export 'src/svg/rendering/root.dart';
+


### PR DESCRIPTION
Support select img element in chrome devtool

before:
https://github.com/openwebf/webf/assets/40893153/acfff80b-ba0f-4c08-90be-6d4200b55430

after:

https://github.com/openwebf/webf/assets/40893153/a2540228-da90-4aa0-9732-918770e2cfe4

