### PR TITLE
feat: quickjs update add property inline cache

### DIFF
--- a/bridge/third_party/quickjs/src/core/runtime.c
+++ b/bridge/third_party/quickjs/src/core/runtime.c
@@ -352,8 +352,7 @@ int JS_SetPrototypeInternal(JSContext* ctx, JSValueConst obj, JSValueConst proto
   if (js_shape_prepare_update(ctx, p, NULL))
     return -1;
   sh = p->shape;
-  if (ic_free_shape_proto_watchpoints(ctx->rt, p->shape))
-    return -1;
+  ic_free_shape_proto_watchpoints(ctx->rt, p->shape);
   if (sh->proto)
     JS_FreeValue(ctx, JS_MKPTR(JS_TAG_OBJECT, sh->proto));
   sh->proto = proto;

--- a/bridge/third_party/quickjs/src/core/types.h
+++ b/bridge/third_party/quickjs/src/core/types.h
@@ -516,7 +516,7 @@ typedef struct JSVarDef {
 #define PC2COLUMN_RANGE 5
 #define PC2COLUMN_OP_FIRST 1
 #define PC2COLUMN_DIFF_PC_MAX ((255 - PC2COLUMN_OP_FIRST) / PC2COLUMN_RANGE)
-#define IC_CACHE_ITEM_CAPACITY 2
+#define IC_CACHE_ITEM_CAPACITY 4
 
 typedef enum JSFunctionKindEnum {
     JS_FUNC_NORMAL = 0,

--- a/bridge/third_party/quickjs/src/core/types.h
+++ b/bridge/third_party/quickjs/src/core/types.h
@@ -516,7 +516,7 @@ typedef struct JSVarDef {
 #define PC2COLUMN_RANGE 5
 #define PC2COLUMN_OP_FIRST 1
 #define PC2COLUMN_DIFF_PC_MAX ((255 - PC2COLUMN_OP_FIRST) / PC2COLUMN_RANGE)
-#define IC_CACHE_ITEM_CAPACITY 8
+#define IC_CACHE_ITEM_CAPACITY 2
 
 typedef enum JSFunctionKindEnum {
     JS_FUNC_NORMAL = 0,


### PR DESCRIPTION
> - Apple M1 Pro
> - macOS Monterey 12.2.1
> - Clang 13.0.0 arm64-apple-darwin21.3.0

|               | openwebf/quickjs (latest)    | quickjs-ng/quickjs (e995085)       | Improvement (%) |
| ------------- | ---------- | ---------- |-----------|
| Richards      | 1324        | 1250       | +5.92 |
| DeltaBlue        | 1281        | 1139       | +12.46|
| Crypto      | 1314        | 1310       | +0.30|
| RayTrace  | 1648        | 1152       | +43.05  |
| EarleyBoyer     | 2225        | 2151       |  +3.44|
| RegExp     | 296        | 258       | +14.72  |
| Splay     | 2467        | 2169       | +13.73|
| SplayLatency     | 9089        | 8197       | +10.88|
| NavierStokes     | 2576        | 2407       | +7.02|
| PdfJS     | 4208        | 4099       | +2.65 |
| Mandreel     | 1173        | 1087       |+7.91|
| MandreelLatency     | 7485        | 7396       | +1.20|
| Gameboy     | 9874        | 9380       | +5.26 |
| CodeLoad     | 14869        | 16578       | -10.30|
| Box2D     | 5184        | 5063       | +2.38|
| Typescript     | 17665        | 17736       | -0.45 |
| Score (version 9)   | 3091        | 2889    | +6.99|
