### PR TITLE
fix: fix crash when binding object had been released by GC.

### DIFF
--- a/.github/workflows/integration_test_flutter.yml
+++ b/.github/workflows/integration_test_flutter.yml
@@ -10,7 +10,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   setup:
-    runs-on: macos-12
+    runs-on: 'macos-14'
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
     steps:
@@ -22,7 +22,7 @@ jobs:
           JSON=$(node -e "console.log(JSON.stringify(require('./integration_tests/spec_group.json').map(j=>j.name)))")
           echo "::set-output name=value::$(echo $JSON)"
   build_bridge:
-    runs-on: macos-12
+    runs-on: 'macos-14'
     steps:
     - uses: actions/checkout@v3
       with:
@@ -73,7 +73,7 @@ jobs:
     - run: cd webf && flutter test
 
   integration_test:
-    runs-on: self-hosted
+    runs-on: 'macos-14'
     needs: [ setup, build_bridge ]
     strategy:
       fail-fast: false
@@ -109,7 +109,7 @@ jobs:
       if: steps.test.outcome != 'success'
       run: exit 1
   multiple_page_test:
-    runs-on: self-hosted
+    runs-on: 'macos-14'
     needs: [ build_bridge ]
     steps:
     - uses: actions/checkout@v3
@@ -136,7 +136,7 @@ jobs:
       run: exit 1
 
   preload_page_test:
-    runs-on: self-hosted
+    runs-on: 'macos-14'
     needs: [ build_bridge ]
     steps:
     - uses: actions/checkout@v3
@@ -162,7 +162,7 @@ jobs:
       if: steps.test.outcome != 'success'
       run: exit 1
   prerendering_page_test:
-    runs-on: self-hosted
+    runs-on: 'macos-14'
     needs: [ build_bridge ]
     steps:
     - uses: actions/checkout@v3
@@ -189,7 +189,7 @@ jobs:
       run: exit 1
 
   memory_leak_test:
-    runs-on: self-hosted
+    runs-on: 'macos-14'
     needs: [ build_bridge ]
     steps:
     - uses: actions/checkout@v3

--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -53,7 +53,8 @@ void NativeBindingObject::HandleCallFromDartSide(DartIsolateContext* dart_isolat
                                                  NativeValue* argv,
                                                  Dart_PersistentHandle dart_object,
                                                  DartInvokeResultCallback result_callback) {
-  if (binding_object->disposed_) return;
+  if (binding_object->disposed_)
+    return;
   AtomicString method = AtomicString(
       binding_object->binding_target_->ctx(),
       std::unique_ptr<AutoFreeNativeString>(reinterpret_cast<AutoFreeNativeString*>(native_method->u.ptr)));

--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -53,6 +53,7 @@ void NativeBindingObject::HandleCallFromDartSide(DartIsolateContext* dart_isolat
                                                  NativeValue* argv,
                                                  Dart_PersistentHandle dart_object,
                                                  DartInvokeResultCallback result_callback) {
+  if (binding_object->disposed_) return;
   AtomicString method = AtomicString(
       binding_object->binding_target_->ctx(),
       std::unique_ptr<AutoFreeNativeString>(reinterpret_cast<AutoFreeNativeString*>(native_method->u.ptr)));

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -77,8 +77,14 @@ BoundingClientRect* Element::getBoundingClientRect(ExceptionState& exception_sta
   NativeValue result = InvokeBindingMethod(
       binding_call_methods::kgetBoundingClientRect, 0, nullptr,
       FlushUICommandReason::kDependentsOnElement | FlushUICommandReason::kDependentsOnLayout, exception_state);
+  NativeBindingObject* native_binding_object = NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(result);
+
+  if (native_binding_object == nullptr) {
+    return nullptr;
+  }
+
   return BoundingClientRect::Create(
-      GetExecutingContext(), NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(result));
+      GetExecutingContext(), native_binding_object);
 }
 
 std::vector<BoundingClientRect*> Element::getClientRects(ExceptionState& exception_state) {
@@ -92,6 +98,10 @@ std::vector<BoundingClientRect*> Element::getClientRects(ExceptionState& excepti
       NativeValueConverter<NativeTypeArray<NativeTypePointer<NativeBindingObject>>>::FromNativeValue(ctx(), result);
   std::vector<BoundingClientRect*> vecRects;
   for (auto& nativeRect : nativeRects) {
+    if (nativeRect == nullptr) {
+      return {};
+    }
+
     BoundingClientRect* rect = BoundingClientRect::Create(GetExecutingContext(), nativeRect);
     vecRects.push_back(rect);
   }

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -77,14 +77,14 @@ BoundingClientRect* Element::getBoundingClientRect(ExceptionState& exception_sta
   NativeValue result = InvokeBindingMethod(
       binding_call_methods::kgetBoundingClientRect, 0, nullptr,
       FlushUICommandReason::kDependentsOnElement | FlushUICommandReason::kDependentsOnLayout, exception_state);
-  NativeBindingObject* native_binding_object = NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(result);
+  NativeBindingObject* native_binding_object =
+      NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(result);
 
   if (native_binding_object == nullptr) {
     return nullptr;
   }
 
-  return BoundingClientRect::Create(
-      GetExecutingContext(), native_binding_object);
+  return BoundingClientRect::Create(GetExecutingContext(), native_binding_object);
 }
 
 std::vector<BoundingClientRect*> Element::getClientRects(ExceptionState& exception_state) {

--- a/bridge/core/frame/window.cc
+++ b/bridge/core/frame/window.cc
@@ -119,8 +119,10 @@ Screen* Window::screen() {
     NativeValue value = GetBindingProperty(
         binding_call_methods::kscreen,
         FlushUICommandReason::kDependentsOnElement | FlushUICommandReason::kDependentsOnLayout, ASSERT_NO_EXCEPTION());
+    NativeBindingObject* native_binding_object = NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
+    if (native_binding_object == nullptr) return nullptr;
     screen_ = MakeGarbageCollected<Screen>(
-        this, NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value));
+        this, native_binding_object);
   }
   return screen_;
 }

--- a/bridge/core/frame/window.cc
+++ b/bridge/core/frame/window.cc
@@ -119,10 +119,11 @@ Screen* Window::screen() {
     NativeValue value = GetBindingProperty(
         binding_call_methods::kscreen,
         FlushUICommandReason::kDependentsOnElement | FlushUICommandReason::kDependentsOnLayout, ASSERT_NO_EXCEPTION());
-    NativeBindingObject* native_binding_object = NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
-    if (native_binding_object == nullptr) return nullptr;
-    screen_ = MakeGarbageCollected<Screen>(
-        this, native_binding_object);
+    NativeBindingObject* native_binding_object =
+        NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
+    if (native_binding_object == nullptr)
+      return nullptr;
+    screen_ = MakeGarbageCollected<Screen>(this, native_binding_object);
   }
   return screen_;
 }

--- a/bridge/core/html/canvas/canvas_rendering_context_2d.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context_2d.cc
@@ -40,6 +40,9 @@ CanvasGradient* CanvasRenderingContext2D::createLinearGradient(double x0,
                           arguments, FlushUICommandReason::kDependentsOnElement, exception_state);
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
+
+  if (native_binding_object == nullptr) return nullptr;
+
   return MakeGarbageCollected<CanvasGradient>(GetExecutingContext(), native_binding_object);
 }
 
@@ -63,6 +66,9 @@ CanvasGradient* CanvasRenderingContext2D::createRadialGradient(double x0,
                           arguments, FlushUICommandReason::kDependentsOnElement, exception_state);
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
+
+  if (native_binding_object == nullptr) return nullptr;
+
   return MakeGarbageCollected<CanvasGradient>(GetExecutingContext(), native_binding_object);
 }
 
@@ -85,6 +91,9 @@ CanvasPattern* CanvasRenderingContext2D::createPattern(
                                           arguments, FlushUICommandReason::kDependentsOnElement, exception_state);
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
+
+  if (native_binding_object == nullptr) return nullptr;
+
   return MakeGarbageCollected<CanvasPattern>(GetExecutingContext(), native_binding_object);
 }
 

--- a/bridge/core/html/canvas/canvas_rendering_context_2d.cc
+++ b/bridge/core/html/canvas/canvas_rendering_context_2d.cc
@@ -41,7 +41,8 @@ CanvasGradient* CanvasRenderingContext2D::createLinearGradient(double x0,
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
 
-  if (native_binding_object == nullptr) return nullptr;
+  if (native_binding_object == nullptr)
+    return nullptr;
 
   return MakeGarbageCollected<CanvasGradient>(GetExecutingContext(), native_binding_object);
 }
@@ -67,7 +68,8 @@ CanvasGradient* CanvasRenderingContext2D::createRadialGradient(double x0,
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
 
-  if (native_binding_object == nullptr) return nullptr;
+  if (native_binding_object == nullptr)
+    return nullptr;
 
   return MakeGarbageCollected<CanvasGradient>(GetExecutingContext(), native_binding_object);
 }
@@ -92,7 +94,8 @@ CanvasPattern* CanvasRenderingContext2D::createPattern(
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
 
-  if (native_binding_object == nullptr) return nullptr;
+  if (native_binding_object == nullptr)
+    return nullptr;
 
   return MakeGarbageCollected<CanvasPattern>(GetExecutingContext(), native_binding_object);
 }

--- a/bridge/core/html/canvas/html_canvas_element.cc
+++ b/bridge/core/html/canvas/html_canvas_element.cc
@@ -21,6 +21,8 @@ CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, 
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
 
+  if (native_binding_object == nullptr) return nullptr;
+
   if (type == canvas_types::k2d) {
     CanvasRenderingContext* context =
         MakeGarbageCollected<CanvasRenderingContext2D>(GetExecutingContext(), native_binding_object);

--- a/bridge/core/html/canvas/html_canvas_element.cc
+++ b/bridge/core/html/canvas/html_canvas_element.cc
@@ -21,7 +21,8 @@ CanvasRenderingContext* HTMLCanvasElement::getContext(const AtomicString& type, 
   NativeBindingObject* native_binding_object =
       NativeValueConverter<NativeTypePointer<NativeBindingObject>>::FromNativeValue(value);
 
-  if (native_binding_object == nullptr) return nullptr;
+  if (native_binding_object == nullptr)
+    return nullptr;
 
   if (type == canvas_types::k2d) {
     CanvasRenderingContext* context =


### PR DESCRIPTION
The `NativeBindingObject` has the potential possiblity to released between the duration of sync the data from Dart thread and JS thread.