### PR TITLE
fix: fix dart element memory leaks when js gc collected.

### DIFF
--- a/bridge/core/dom/events/event_target.cc
+++ b/bridge/core/dom/events/event_target.cc
@@ -373,7 +373,7 @@ NativeValue EventTarget::HandleDispatchEventFromDart(int32_t argc, const NativeV
   assert(event->currentTarget() != nullptr);
 
   auto* window = DynamicTo<Window>(event->target());
-  if (window != nullptr && event->type() == event_type_names::kload) {
+  if (window != nullptr && (event->type() == event_type_names::kload || event->type() == event_type_names::kgcopen)) {
     window->OnLoadEventFired();
   }
 

--- a/bridge/core/events/event_type_names.json5
+++ b/bridge/core/events/event_type_names.json5
@@ -223,6 +223,7 @@
     "webglcontextrestored",
     "wheel",
     "zoom",
-    "intersectionchange"
+    "intersectionchange",
+    "gcopen"
   ]
 }

--- a/bridge/third_party/quickjs/src/core/runtime.c
+++ b/bridge/third_party/quickjs/src/core/runtime.c
@@ -3006,7 +3006,7 @@ JSRuntime* JS_NewRuntime2(const JSMallocFunctions* mf, void* opaque) {
     rt->mf.js_malloc_usable_size = js_malloc_usable_size_unknown;
   }
   rt->malloc_state = ms;
-  rt->malloc_gc_threshold = 64 * 1024 * 1024; // 64 MB as a start
+  rt->malloc_gc_threshold = 2 * 1024 * 1024; // 2 MB as a start
   rt->gc_off = FALSE;
 
 #ifdef CONFIG_BIGNUM

--- a/webf/lib/src/dom/comment.dart
+++ b/webf/lib/src/dom/comment.dart
@@ -19,4 +19,9 @@ class Comment extends CharacterData {
 
   @override
   int get length => data.length;
+
+  @override
+  String toString() {
+    return 'Comment()';
+  }
 }

--- a/webf/lib/src/dom/container_node.dart
+++ b/webf/lib/src/dom/container_node.dart
@@ -17,7 +17,7 @@ bool collectChildrenAndRemoveFromOldParent(Node node, List<Node> nodes) {
   }
   nodes.add(node);
   ContainerNode? oldParent = node.parentNode;
-  if (oldParent != null) {
+  if (oldParent != null && node.isConnected) {
     oldParent.removeChild(node);
   }
   return nodes.isNotEmpty;

--- a/webf/lib/src/dom/container_node.dart
+++ b/webf/lib/src/dom/container_node.dart
@@ -92,7 +92,7 @@ abstract class ContainerNode extends Node {
 
     // 6. Mark this element to dirty elements.
     if (this is Element) {
-      ownerDocument.styleDirtyElements.add(this as Element);
+      ownerDocument.markElementStyleDirty(this as Element);
     }
 
     // 7. Trigger connected callback
@@ -180,7 +180,7 @@ abstract class ContainerNode extends Node {
     }
 
     if (this is Element) {
-      ownerDocument.styleDirtyElements.add(this as Element);
+      ownerDocument.markElementStyleDirty(this as Element);
     }
 
     bool isOldChildConnected = child.isConnected;
@@ -222,7 +222,7 @@ abstract class ContainerNode extends Node {
     _insertNode(targets, null, _adoptAndAppendChild);
 
     if (this is Element) {
-      ownerDocument.styleDirtyElements.add(this as Element);
+      ownerDocument.markElementStyleDirty(this as Element);
     }
 
     if (newChild.isConnected) {

--- a/webf/lib/src/dom/element.dart
+++ b/webf/lib/src/dom/element.dart
@@ -953,7 +953,7 @@ abstract class Element extends ContainerNode with ElementBase, ElementEventMixin
     flutterWidget = null;
     flutterWidgetElement = null;
     ownerDocument.inactiveRenderObjects.add(renderer);
-    ownerDocument.styleDirtyElements.remove(this);
+    ownerDocument.clearElementStyleDirty(this);
     _beforeElement?.dispose();
     _beforeElement = null;
     _afterElement?.dispose();

--- a/webf/lib/src/dom/element.dart
+++ b/webf/lib/src/dom/element.dart
@@ -953,6 +953,7 @@ abstract class Element extends ContainerNode with ElementBase, ElementEventMixin
     flutterWidget = null;
     flutterWidgetElement = null;
     ownerDocument.inactiveRenderObjects.add(renderer);
+    ownerDocument.styleDirtyElements.remove(this);
     _beforeElement?.dispose();
     _beforeElement = null;
     _afterElement?.dispose();

--- a/webf/lib/src/dom/node.dart
+++ b/webf/lib/src/dom/node.dart
@@ -309,7 +309,9 @@ abstract class Node extends EventTarget implements RenderObjectNode, LifecycleCa
   /// Release any resources held by this node.
   @override
   void dispose() async {
-    parentNode?.removeChild(this);
+    if (isConnected) {
+      parentNode?.removeChild(this);
+    }
     if (this is! Document) {
       assert(!isRendererAttachedToSegmentTree, 'Should unmount $this before calling dispose.');
     }

--- a/webf/lib/src/dom/style_node_manager.dart
+++ b/webf/lib/src/dom/style_node_manager.dart
@@ -82,7 +82,7 @@ class StyleNodeManager {
     } else {
       final root = document.documentElement;
       if (root != null) {
-        document.styleDirtyElements.add(root);
+        document.markElementStyleDirty(root);
       }
     }
     document.handleStyleSheets(newSheets);
@@ -113,7 +113,7 @@ class StyleNodeManager {
       }
       final rules = collector.matchedRules(changedRuleSet, node);
       if (rules.isNotEmpty) {
-        document.styleDirtyElements.add(node);
+        document.markElementStyleDirty(node);
       }
       if (node.childNodes.isNotEmpty) {
         stack.addAll(node.childNodes);

--- a/webf/lib/src/dom/text_node.dart
+++ b/webf/lib/src/dom/text_node.dart
@@ -116,7 +116,7 @@ class TextNode extends CharacterData {
 
   @override
   String toString() {
-    return 'TextNode($hashCode)';
+    return 'TextNode($data)';
   }
 
   // Detach renderObject of current node from parent

--- a/webf/lib/src/dom/window.dart
+++ b/webf/lib/src/dom/window.dart
@@ -21,6 +21,7 @@ class Window extends EventTarget {
       : screen = Screen(context!.contextId, document.controller.ownerFlutterView, document.controller.view),
         super(context) {
     BindingBridge.listenEvent(this, 'load');
+    BindingBridge.listenEvent(this, 'gcopen');
   }
 
   @override

--- a/webf/lib/src/html/head.dart
+++ b/webf/lib/src/html/head.dart
@@ -163,7 +163,7 @@ class LinkElement extends Element {
         final String cssString = await resolveStringFromData(bundle.data!);
         _styleSheet = CSSParser(cssString, href: href).parse();
         _styleSheet?.href = href;
-        ownerDocument.styleDirtyElements.add(ownerDocument.documentElement!);
+        ownerDocument.markElementStyleDirty(ownerDocument.documentElement!);
         ownerDocument.styleNodeManager.appendPendingStyleSheet(_styleSheet!);
         ownerDocument.updateStyleIfNeeded();
 
@@ -271,7 +271,7 @@ mixin StyleElementMixin on Element {
         _styleSheet = CSSParser(text).parse();
       }
       if (_styleSheet != null) {
-        ownerDocument.styleDirtyElements.add(ownerDocument.documentElement!);
+        ownerDocument.markElementStyleDirty(ownerDocument.documentElement!);
         ownerDocument.styleNodeManager.appendPendingStyleSheet(_styleSheet!);
         ownerDocument.updateStyleIfNeeded();
       }

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -693,7 +693,6 @@ class WebFViewController implements WidgetsBindingObserver {
     bindingObject?.dispose();
     view.removeBindingObject(pointer);
     view.disposeTargetIdToDevNodeIdMap(bindingObject);
-    view.document.styleDirtyElements.remove(bindingObject);
     malloc.free(pointer);
   }
 

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -325,6 +325,11 @@ class WebFViewController implements WidgetsBindingObserver {
     window = Window(BindingContext(view, _contextId, pointer), document);
     _registerPlatformBrightnessChange();
 
+    // 3 seconds should be enough for page loading, make sure the JavaScript GC was opened.
+    Timer(Duration(seconds: 3), () {
+      window.dispatchEvent(Event('gcopen'));
+    });
+
     // Blur input element when new input focused.
     window.addEventListener(EVENT_CLICK, (event) async {
       if (event.target is Element) {

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -693,6 +693,7 @@ class WebFViewController implements WidgetsBindingObserver {
     bindingObject?.dispose();
     view.removeBindingObject(pointer);
     view.disposeTargetIdToDevNodeIdMap(bindingObject);
+    view.document.styleDirtyElements.remove(bindingObject);
     malloc.free(pointer);
   }
 


### PR DESCRIPTION
The `styleDirtyElements` member still holding the reference when element disposed.