### PR TITLE
fix: fix other element's memory leaks due to ImageProvider cached.

### DIFF
--- a/integration_tests/specs/css/css-flexbox/align-items.ts
+++ b/integration_tests/specs/css/css-flexbox/align-items.ts
@@ -1171,6 +1171,7 @@ describe('align-items', () => {
   });
 
   it('should works with img with no size set', async () => {
+    let img;
     const container = createElement(
       'div',
       {
@@ -1181,7 +1182,7 @@ describe('align-items', () => {
         },
       },
       [
-        (createElement('img', {
+        img = (createElement('img', {
           src: 'assets/100x100-green.png',
           style: {
             "marginLeft": "20px",
@@ -1191,7 +1192,9 @@ describe('align-items', () => {
     );
 
     document.body.appendChild(container);
-    await snapshot(0.2);
+    onImageLoad(img, async () => {
+      await snapshot(0.2);
+    });
   });
 });
 

--- a/integration_tests/specs/css/css-position/absolute-replaced.ts
+++ b/integration_tests/specs/css/css-position/absolute-replaced.ts
@@ -172,7 +172,6 @@ describe('absolute-replaced', () => {
     let p;
     let div;
     let img1;
-    let img2;
     p = createElement(
       'p',
       {
@@ -215,7 +214,7 @@ describe('absolute-replaced', () => {
             'box-sizing': 'border-box',
           },
         }),
-        img2 = createElement('div', {
+        createElement('div', {
           style: {
             position: 'absolute',
             background: 'orange',
@@ -231,7 +230,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    onDoubleImageLoad(img1, img2, async () => {
+    onImageLoad(img1,async () => {
       await snapshot(0.1);
       done();
     });
@@ -240,7 +239,6 @@ describe('absolute-replaced', () => {
     let p;
     let div;
     let img1;
-    let img2;
     p = createElement(
       'p',
       {
@@ -283,7 +281,7 @@ describe('absolute-replaced', () => {
             'box-sizing': 'border-box',
           },
         }),
-        img2 = createElement('div', {
+        createElement('div', {
           style: {
             position: 'absolute',
             background: 'blue',
@@ -299,7 +297,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    onDoubleImageLoad(img1, img2, async () => {
+    onImageLoad(img1, async () => {
       await snapshot(0.1);
       done();
     });

--- a/integration_tests/specs/css/css-position/absolute-replaced.ts
+++ b/integration_tests/specs/css/css-position/absolute-replaced.ts
@@ -1,8 +1,9 @@
 /*auto generated*/
 describe('absolute-replaced', () => {
-  it('height-001-ref', async () => {
+  it('height-001-ref', async (done) => {
     let p;
     let div;
+    let img;
     p = createElement(
       'p',
       {
@@ -33,7 +34,7 @@ describe('absolute-replaced', () => {
         },
       },
       [
-        createElement('img', {
+        img = createElement('img', {
           src: 'assets/blue15x15.png',
           alt: 'Image download support must be enabled',
           style: {},
@@ -43,11 +44,15 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await snapshot(0.1);
+    onImageLoad(img, async () => {
+      await snapshot(0.1);
+      done();
+    });
   });
-  it('height-001', async () => {
+  it('height-001', async (done) => {
     let p;
     let div;
+    let img;
     p = createElement(
       'p',
       {
@@ -83,7 +88,7 @@ describe('absolute-replaced', () => {
         },
       },
       [
-        createElement('img', {
+        img = createElement('img', {
           alt: 'blue 15x15',
           src: 'assets/blue15x15.png',
           style: {
@@ -98,11 +103,16 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await snapshot(0.1);
+    onImageLoad(img, async () => {
+      await snapshot(0.1);
+      done();
+    });
   });
-  it('height-002-ref', async () => {
+  it('height-002-ref', async (done) => {
     let p;
     let div;
+    let img1;
+    let img2;
     p = createElement(
       'p',
       {
@@ -134,14 +144,14 @@ describe('absolute-replaced', () => {
         },
       },
       [
-        createElement('img', {
+        img1 = createElement('img', {
           src: 'assets/blue15x15.png',
           alt: 'Image download support must be enabled',
           style: {
             'box-sizing': 'border-box',
           },
         }),
-        createElement('img', {
+        img2 = createElement('img', {
           src: 'assets/swatch-orange.png',
           alt: 'Image download support must be enabled',
           style: {
@@ -153,11 +163,16 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await snapshot(0.1);
+    onDoubleImageLoad(img1, img2, async () => {
+      await snapshot(0.1);
+      done();
+    });
   });
-  it('height-002', async () => {
+  it('height-002', async (done) => {
     let p;
     let div;
+    let img1;
+    let img2;
     p = createElement(
       'p',
       {
@@ -190,7 +205,7 @@ describe('absolute-replaced', () => {
         },
       },
       [
-        createElement('img', {
+        img1 = createElement('img', {
           alt: 'blue 15x15',
           src: 'assets/blue15x15.png',
           style: {
@@ -200,7 +215,7 @@ describe('absolute-replaced', () => {
             'box-sizing': 'border-box',
           },
         }),
-        createElement('div', {
+        img2 = createElement('div', {
           style: {
             position: 'absolute',
             background: 'orange',
@@ -216,11 +231,16 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await snapshot(0.1);
+    onDoubleImageLoad(img1, img2, async () => {
+      await snapshot(0.1);
+      done();
+    });
   });
-  it('height-003', async () => {
+  it('height-003', async (done) => {
     let p;
     let div;
+    let img1;
+    let img2;
     p = createElement(
       'p',
       {
@@ -253,7 +273,7 @@ describe('absolute-replaced', () => {
         },
       },
       [
-        createElement('img', {
+        img1 = createElement('img', {
           alt: 'Image download support must be enabled',
           src: 'assets/swatch-orange.png',
           style: {
@@ -263,7 +283,7 @@ describe('absolute-replaced', () => {
             'box-sizing': 'border-box',
           },
         }),
-        createElement('div', {
+        img2 = createElement('div', {
           style: {
             position: 'absolute',
             background: 'blue',
@@ -279,7 +299,10 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await snapshot(0.1);
+    onDoubleImageLoad(img1, img2, async () => {
+      await snapshot(0.1);
+      done();
+    });
   });
   it('height-004-ref', async () => {
     let p;
@@ -477,9 +500,11 @@ describe('absolute-replaced', () => {
 
     await snapshot();
   });
-  it('height-006-ref', async () => {
+  it('height-006-ref', async (done) => {
     let p;
     let div;
+    let img1;
+    let img2;
     p = createElement(
       'p',
       {
@@ -505,7 +530,7 @@ describe('absolute-replaced', () => {
         style: {},
       },
       [
-        createElement('img', {
+        img1 = createElement('img', {
           src: 'assets/blue15x15.png',
           alt: 'Image download support must be enabled',
           style: {
@@ -513,7 +538,7 @@ describe('absolute-replaced', () => {
             width: '200px',
           },
         }),
-        createElement('img', {
+        img2 = createElement('img', {
           src: 'assets/swatch-orange.png',
           alt: 'Image download support must be enabled',
           style: {
@@ -526,7 +551,10 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await snapshot(0.1);
+    onDoubleImageLoad(img1, img2, async () => {
+      await snapshot(0.1);
+      done();
+    });
   });
   it('height-007-ref', async () => {
     let p;

--- a/integration_tests/specs/css/css-position/position-static.ts
+++ b/integration_tests/specs/css/css-position/position-static.ts
@@ -1,8 +1,9 @@
 /*auto generated*/
 describe('position-static', () => {
-  it('001-ref', async () => {
+  it('001-ref', async (done) => {
     let p;
     let div;
+    let img;
     p = createElement(
       'p',
       {
@@ -31,7 +32,7 @@ describe('position-static', () => {
         createElement('br', {
           style: {},
         }),
-        createElement('img', {
+        img = createElement('img', {
           src: 'assets/swatch-blue.png',
           width: '192',
           height: '172',
@@ -43,7 +44,10 @@ describe('position-static', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await snapshot(0.1);
+    onImageLoad(img, async () => {
+      await snapshot(0.1);
+      done();
+    });
   });
   it('001', async () => {
     let p;

--- a/webf/lib/src/css/background.dart
+++ b/webf/lib/src/css/background.dart
@@ -275,8 +275,8 @@ class CSSBackgroundImage {
   static void _handleBitFitImageLoad(
       Element element, int naturalWidth, int naturalHeight, int frameCount) {
     if (frameCount > 1) {
-      element.renderStyle.target.forceToRepaintBoundary = true;
-      element.renderStyle.target.renderBoxModel!.invalidateBoxPainter();
+      element.forceToRepaintBoundary = true;
+      element.renderBoxModel!.invalidateBoxPainter();
     }
   }
 

--- a/webf/lib/src/css/background.dart
+++ b/webf/lib/src/css/background.dart
@@ -274,7 +274,7 @@ class CSSBackgroundImage {
 
   static void _handleBitFitImageLoad(
       Element element, int naturalWidth, int naturalHeight, int frameCount) {
-    if (frameCount > 1) {
+    if (frameCount > 1 && !element.renderStyle.target.isRepaintBoundary) {
       element.forceToRepaintBoundary = true;
       element.renderBoxModel!.invalidateBoxPainter();
     }

--- a/webf/lib/src/css/background.dart
+++ b/webf/lib/src/css/background.dart
@@ -274,7 +274,7 @@ class CSSBackgroundImage {
 
   static void _handleBitFitImageLoad(
       Element element, int naturalWidth, int naturalHeight, int frameCount) {
-    if (frameCount > 1 && !element.renderStyle.target.isRepaintBoundary) {
+    if (frameCount > 1 && !element.isRepaintBoundary) {
       element.forceToRepaintBoundary = true;
       element.renderBoxModel!.invalidateBoxPainter();
     }

--- a/webf/lib/src/css/background.dart
+++ b/webf/lib/src/css/background.dart
@@ -9,6 +9,7 @@ import 'dart:ui';
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/rendering.dart';
+import 'package:webf/dom.dart';
 import 'package:webf/painting.dart';
 import 'package:webf/html.dart';
 import 'package:webf/css.dart';
@@ -178,6 +179,10 @@ mixin CSSBackgroundMixin on RenderStyle {
 
   set backgroundImage(CSSBackgroundImage? value) {
     if (value == _backgroundImage) return;
+    if (_backgroundImage != null) {
+      _backgroundImage!.dispose();
+    }
+
     _backgroundImage = value;
     renderBoxModel?.markNeedsPaint();
   }
@@ -255,16 +260,24 @@ class CSSBackgroundImage {
 
   ImageProvider? _image;
 
-  Future<ImageLoadResponse> _obtainImage(Uri url) async {
+  static Future<ImageLoadResponse> _obtainImage(Element element, Uri url) async {
     ImageRequest request = ImageRequest.fromUri(url);
     // Increment count when request.
-    controller.view.document.incrementRequestCount();
+    element.ownerDocument.controller.view.document.incrementRequestCount();
 
-    ImageLoadResponse data = await request.obtainImage(controller);
+    ImageLoadResponse data = await request.obtainImage(element.ownerDocument.controller);
 
     // Decrement count when response.
-    controller.view.document.decrementRequestCount();
+    element.ownerDocument.controller.view.document.decrementRequestCount();
     return data;
+  }
+
+  static void _handleBitFitImageLoad(
+      Element element, int naturalWidth, int naturalHeight, int frameCount) {
+    if (frameCount > 1) {
+      element.renderStyle.target.forceToRepaintBoundary = true;
+      element.renderStyle.target.renderBoxModel!.invalidateBoxPainter();
+    }
   }
 
   ImageProvider? get image {
@@ -285,15 +298,11 @@ class CSSBackgroundImage {
           return _image = BoxFitImage(
             boxFit: renderStyle.backgroundSize.fit,
             url: uri,
+            controller: controller,
+            targetElementPtr: renderStyle.target.pointer!,
             loadImage: _obtainImage,
-              onImageLoad: (int naturalWidth, int naturalHeight, int frameCount) {
-                if (frameCount > 1) {
-                   renderStyle.target.forceToRepaintBoundary = true;
-                   renderStyle.target.renderBoxModel!.invalidateBoxPainter();
-                }
-              },
-            devicePixelRatio: ownerFlutterView.devicePixelRatio
-          );
+            onImageLoad: _handleBitFitImageLoad,
+            devicePixelRatio: ownerFlutterView.devicePixelRatio);
         }
       }
     }
@@ -502,6 +511,10 @@ class CSSBackgroundImage {
     }
     return 'none';
   }
+
+  void dispose() {
+    _image = null;
+  }
 }
 
 class CSSBackgroundPosition {
@@ -701,8 +714,8 @@ class CSSBackground {
   }
 }
 
-void _applyColorAndStops(int start, List<String> args, List<Color> colors, List<double> stops,
-    RenderStyle renderStyle, String propertyName,
+void _applyColorAndStops(
+    int start, List<String> args, List<Color> colors, List<double> stops, RenderStyle renderStyle, String propertyName,
     [double? gradientLength]) {
   // colors should more than one, otherwise invalid
   if (args.length - start - 1 > 0) {

--- a/webf/lib/src/css/render_style.dart
+++ b/webf/lib/src/css/render_style.dart
@@ -1626,6 +1626,7 @@ class CSSRenderStyle extends RenderStyle
   void detach() {
     // Clear reference to it's parent.
     parent = null;
+    backgroundImage = null;
   }
 
   // Find ancestor render style with display of not inline.

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -485,19 +485,21 @@ class ImageElement extends Element {
 
   // Invoke when image descriptor has created.
   // We can know the naturalWidth and naturalHeight of current image.
-  void _onImageLoad(int width, int height, int frameCount) {
-    naturalWidth = width;
-    naturalHeight = height;
-    _resizeImage();
+  static void _onImageLoad(Element element, int width, int height, int frameCount) {
+    ImageElement self = element as ImageElement;
+
+    self.naturalWidth = width;
+    self.naturalHeight = height;
+    self._resizeImage();
 
     // Multi frame image should wrap a repaint boundary for better composite performance.
     if (frameCount > 1) {
-      forceToRepaintBoundary = true;
-      _watchAnimatedImageWhenVisible();
+      self.forceToRepaintBoundary = true;
+      self._watchAnimatedImageWhenVisible();
     }
 
     // Decrement load event delay count after decode.
-    ownerDocument.decrementLoadEventDelayCount();
+    self.ownerDocument.decrementLoadEventDelayCount();
   }
 
   // Callback when image are loaded, encoded and available to use.
@@ -591,7 +593,7 @@ class ImageElement extends Element {
 
   void _loadSVGImage() {
     final builder =
-        SVGRenderBoxBuilder(obtainImage(_resolvedUri!), target: this);
+        SVGRenderBoxBuilder(obtainImage(this, _resolvedUri!), target: this);
 
     builder.decode().then((renderObject) {
       final size = builder.getIntrinsicSize();
@@ -624,9 +626,11 @@ class ImageElement extends Element {
       provider = _currentImageProvider = BoxFitImage(
         boxFit: objectFit,
         url: _resolvedUri!,
+        targetElementPtr: pointer!,
         loadImage: obtainImage,
         onImageLoad: _onImageLoad,
-        devicePixelRatio: ownerDocument.defaultView.devicePixelRatio
+        controller: ownerDocument.controller,
+        devicePixelRatio: ownerDocument.defaultView.devicePixelRatio,
       );
     }
 
@@ -663,15 +667,16 @@ class ImageElement extends Element {
 
   // To load the resource, and dispatch load event.
   // https://html.spec.whatwg.org/multipage/images.html#when-to-obtain-images
-  Future<ImageLoadResponse> obtainImage(Uri url) async {
-    ImageRequest request = _currentRequest = ImageRequest.fromUri(url);
+  static Future<ImageLoadResponse> obtainImage(Element element, Uri url) async {
+    var self = element as ImageElement;
+    ImageRequest request = self._currentRequest = ImageRequest.fromUri(url);
     // Increment count when request.
-    ownerDocument.incrementRequestCount();
+    self.ownerDocument.incrementRequestCount();
 
-    final data = await request.obtainImage(ownerDocument.controller);
+    final data = await request.obtainImage(self.ownerDocument.controller);
 
     // Decrement count when response.
-    ownerDocument.decrementRequestCount();
+    self.ownerDocument.decrementRequestCount();
 
     return data;
   }

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -493,7 +493,7 @@ class ImageElement extends Element {
     self._resizeImage();
 
     // Multi frame image should wrap a repaint boundary for better composite performance.
-    if (frameCount > 1 && !isRepaintBoundary) {
+    if (frameCount > 1 && !self.isRepaintBoundary) {
       self.forceToRepaintBoundary = true;
       self._watchAnimatedImageWhenVisible();
     }

--- a/webf/lib/src/html/img.dart
+++ b/webf/lib/src/html/img.dart
@@ -493,7 +493,7 @@ class ImageElement extends Element {
     self._resizeImage();
 
     // Multi frame image should wrap a repaint boundary for better composite performance.
-    if (frameCount > 1) {
+    if (frameCount > 1 && !isRepaintBoundary) {
       self.forceToRepaintBoundary = true;
       self._watchAnimatedImageWhenVisible();
     }

--- a/webf/lib/src/rendering/box_model.dart
+++ b/webf/lib/src/rendering/box_model.dart
@@ -854,9 +854,6 @@ class RenderBoxModel extends RenderBox
     // Copy render style
       ..renderStyle = renderStyle
 
-    // Copy box decoration
-      ..boxPainter = boxPainter
-
     // Copy overflow
       ..scrollListener = scrollListener
       ..scrollablePointerListener = scrollablePointerListener


### PR DESCRIPTION
By default, Flutter caches the ImageProvider globally. However, these providers also hold strong references to WebF's elements. 

This PR removes these strong references to ensure elements can be garbage collected freely, except for the ImageProviders.