### PR TITLE
fix: fix atomic string free crash at dispose dart context.

### DIFF
--- a/bridge/scripts/code_generator/templates/idl_templates/union.cc.tpl
+++ b/bridge/scripts/code_generator/templates/idl_templates/union.cc.tpl
@@ -42,7 +42,7 @@ std::shared_ptr<<%= generateUnionTypeClassName(unionType) %>> <%= generateUnionT
 <% }) %>
 
 <%= generateUnionTypeClassName(unionType) %> ::~<%= generateUnionTypeClassName(unionType) %> () {
-  Clear();
+
 }
 
 JSValue <%= generateUnionTypeClassName(unionType) %>::ToQuickJSValue(JSContext* ctx, ExceptionState& exception_state) const {

--- a/integration_tests/specs/css/css-images/object-fit.ts
+++ b/integration_tests/specs/css/css-images/object-fit.ts
@@ -217,7 +217,7 @@ describe('object-fit', () => {
     );
     BODY.appendChild(image);
 
-    await snapshot(0.1);
+    await snapshot(0.2);
   });
 
   it('should work with scale-down when it behaves as none', async () => {

--- a/integration_tests/specs/css/css-transitions/transform-matrix.ts
+++ b/integration_tests/specs/css/css-transitions/transform-matrix.ts
@@ -20,7 +20,7 @@ describe('Transition transform', () => {
     });
 
     requestAnimationFrame(async () => {
-      await snapshot();
+      await snapshot(0.1);
       setElementStyle(container1, {
         transform: 'matrix(0,1,1,1,10,10)',
       });

--- a/webf/lib/src/css/positioned.dart
+++ b/webf/lib/src/css/positioned.dart
@@ -35,7 +35,7 @@ Offset _getPlaceholderToParentOffset(RenderPositionPlaceholder? placeholder, Ren
   Offset positionHolderScrollOffset = _getRenderPositionHolderScrollOffset(placeholder, parent) ?? Offset.zero;
   // Offset of positioned element should exclude scroll offset to its containing block.
   Offset toParentOffset = placeholder.getOffsetToAncestor(Offset.zero, parent, excludeScrollOffset: true);
-  Offset placeholderOffset = -positionHolderScrollOffset + toParentOffset;
+  Offset placeholderOffset = positionHolderScrollOffset + toParentOffset;
 
   return placeholderOffset;
 }


### PR DESCRIPTION
Fix AtomicString free crash due to built-in-string already freed

<img width="1480" alt="image" src="https://github.com/openwebf/webf/assets/4409743/ef8386a0-8c7b-43f4-babc-c60bfdd96abe">

