### PR TITLE
fix: iOS FontFamilyFallback on -apple-system style, display error on Vietnamese lang

### DIFF
--- a/webf/lib/src/css/text.dart
+++ b/webf/lib/src/css/text.dart
@@ -791,6 +791,12 @@ class CSSText {
           // Default fantasy font in MacOS: Papyrus
           resolvedFamily.addAll(['Papyrus', 'Impact']);
           break;
+        case '-apple-system':
+        case 'system-ui':
+          // Default system-ui font in iOS and iPadOS: .SF UI Display
+          // Default system-ui font in Android (4.0+): Roboto
+          resolvedFamily.addAll(['Roboto', '.SF UI Display', '.SF UI Text']);
+          break;
         default:
           resolvedFamily.add(familyName);
       }


### PR DESCRIPTION
<img width="699" alt="image" src="https://github.com/openwebf/webf/assets/5006424/1616bb6d-0724-48f1-a3f3-bd46554db9fe">