### PR TITLE
JSRuntime lifetime managed by WebFPage lifetime

### DIFF
--- a/bridge/core/dart_isolate_context.cc
+++ b/bridge/core/dart_isolate_context.cc
@@ -93,10 +93,12 @@ void DartIsolateContext::FinalizeJSRuntime() {
   HTMLElementFactory::Dispose();
   SVGElementFactory::Dispose();
   EventFactory::Dispose();
-  ClearUpWires(runtime_);
-  JS_TurnOnGC(runtime_);
-  JS_FreeRuntime(runtime_);
-  runtime_ = nullptr;
+  if (runtime_) {
+    ClearUpWires(runtime_);
+    JS_TurnOnGC(runtime_);
+    JS_FreeRuntime(runtime_);
+    runtime_ = nullptr;
+  }
   is_name_installed_ = false;
 }
 
@@ -110,6 +112,7 @@ DartIsolateContext::DartIsolateContext(const uint64_t* dart_methods, int32_t dar
 }
 
 JSRuntime* DartIsolateContext::runtime() {
+  assert_m(runtime_ != nullptr, "nullptr is unsafe");
   return runtime_;
 }
 

--- a/bridge/core/dart_isolate_context.cc
+++ b/bridge/core/dart_isolate_context.cc
@@ -85,20 +85,20 @@ void DartIsolateContext::InitializeJSRuntime() {
 }
 
 void DartIsolateContext::FinalizeJSRuntime() {
-  if (running_dart_isolates > 0)
+  if (running_dart_isolates > 0 ||
+      runtime_ == nullptr) {
     return;
+  }
 
   // Prebuilt strings stored in JSRuntime. Only needs to dispose when runtime disposed.
   names_installer::Dispose();
   HTMLElementFactory::Dispose();
   SVGElementFactory::Dispose();
   EventFactory::Dispose();
-  if (runtime_) {
-    ClearUpWires(runtime_);
-    JS_TurnOnGC(runtime_);
-    JS_FreeRuntime(runtime_);
-    runtime_ = nullptr;
-  }
+  ClearUpWires(runtime_);
+  JS_TurnOnGC(runtime_);
+  JS_FreeRuntime(runtime_);
+  runtime_ = nullptr;
   is_name_installed_ = false;
 }
 
@@ -262,6 +262,10 @@ void DartIsolateContext::RemovePageSync(double thread_identity, WebFPage* page) 
       pages_in_ui_thread_.erase(it);
       break;
     }
+  }
+
+  if (pages_in_ui_thread_.empty()) {
+    FinalizeJSRuntime();
   }
 }
 

--- a/bridge/core/dart_isolate_context.h
+++ b/bridge/core/dart_isolate_context.h
@@ -74,6 +74,9 @@ class DartIsolateContext {
  private:
   static void InitializeJSRuntime();
   static void FinalizeJSRuntime();
+  static std::unique_ptr<WebFPage> InitializeNewPageSync(DartIsolateContext* dart_isolate_context,
+                                                         size_t sync_buffer_size,
+                                                         double page_context_id);
   static void InitializeNewPageInJSThread(PageGroup* page_group,
                                           DartIsolateContext* dart_isolate_context,
                                           double page_context_id,

--- a/bridge/include/webf_bridge.h
+++ b/bridge/include/webf_bridge.h
@@ -147,6 +147,6 @@ WEBF_EXPORT_C void executeNativeCallback(DartWork* work_ptr);
 WEBF_EXPORT_C
 void init_dart_dynamic_linking(void* data);
 WEBF_EXPORT_C
-void register_dart_context_finalizer(Dart_Handle dart_handle, void* dart_isolate_context);
+void on_dart_context_finalized(void* dart_isolate_context);
 
 #endif  // WEBF_BRIDGE_EXPORT_H

--- a/bridge/webf_bridge.cc
+++ b/bridge/webf_bridge.cc
@@ -67,14 +67,10 @@ void* allocateNewPageSync(double thread_identity, void* ptr) {
   auto* dart_isolate_context = (webf::DartIsolateContext*)ptr;
   assert(dart_isolate_context != nullptr);
 
-  dart_isolate_context->profiler()->StartTrackInitialize();
-
   void* result = static_cast<webf::DartIsolateContext*>(dart_isolate_context)->AddNewPageSync(thread_identity);
 #if ENABLE_LOG
   WEBF_LOG(INFO) << "[Dispatcher]: allocateNewPageSync Call END";
 #endif
-
-  dart_isolate_context->profiler()->FinishTrackInitialize();
 
   return result;
 }

--- a/bridge/webf_bridge.cc
+++ b/bridge/webf_bridge.cc
@@ -285,7 +285,7 @@ void clearUICommandItems(void* page_) {
 }
 
 // Callbacks when dart context object was finalized by Dart GC.
-static void finalize_dart_context(void* isolate_callback_data, void* peer) {
+static void finalize_dart_context(void* peer) {
   WEBF_LOG(VERBOSE) << "[Dispatcher]: BEGIN FINALIZE DART CONTEXT: ";
   auto* dart_isolate_context = (webf::DartIsolateContext*)peer;
   dart_isolate_context->Dispose([dart_isolate_context]() {
@@ -302,9 +302,8 @@ void init_dart_dynamic_linking(void* data) {
   }
 }
 
-void register_dart_context_finalizer(Dart_Handle dart_handle, void* dart_isolate_context) {
-  Dart_NewFinalizableHandle_DL(dart_handle, reinterpret_cast<void*>(dart_isolate_context),
-                               sizeof(webf::DartIsolateContext), finalize_dart_context);
+void on_dart_context_finalized(void* dart_isolate_context) {
+  finalize_dart_context(dart_isolate_context);
 }
 
 int8_t isJSThreadBlocked(void* dart_isolate_context_, double context_id) {

--- a/webf/lib/src/bridge/bridge.dart
+++ b/webf/lib/src/bridge/bridge.dart
@@ -28,10 +28,10 @@ bool isJSRunningInDedicatedThread(double contextId) {
 
 /// Init bridge
 FutureOr<double> initBridge(WebFViewController view, WebFThread runningThread) async {
-  dartContext ??= DartContext();
-
   // Setup binding bridge.
   BindingBridge.setup();
+  
+  dartContext ??= DartContext();
 
   double newContextId = runningThread.identity();
   await allocateNewPage(runningThread is FlutterUIThread, newContextId, runningThread.syncBufferSize());

--- a/webf/lib/src/bridge/bridge.dart
+++ b/webf/lib/src/bridge/bridge.dart
@@ -7,15 +7,24 @@ import 'dart:async';
 import 'dart:ffi';
 import 'package:webf/launcher.dart';
 
+import 'dynamic_library.dart';
 import 'binding.dart';
 import 'from_native.dart';
 import 'to_native.dart';
 import 'multiple_thread.dart';
 
-class DartContext {
+typedef NativeOnDartContextFinalized = Void Function(Pointer<Void> data);
+typedef DartOnDartContextFinalized = void Function(Pointer<Void> data);
+
+final _initDartDynamicLinking = WebFDynamicLibrary.ref
+    .lookup<NativeFunction<NativeOnDartContextFinalized>>('on_dart_context_finalized');
+
+class DartContext implements Finalizable {
+  static final _finalizer = NativeFinalizer(_initDartDynamicLinking);
+
   DartContext() : pointer = initDartIsolateContext(makeDartMethodsData()) {
     initDartDynamicLinking();
-    registerDartContextFinalizer(this);
+    _finalizer.attach(this, pointer);
   }
   final Pointer<Void> pointer;
 }
@@ -30,7 +39,7 @@ bool isJSRunningInDedicatedThread(double contextId) {
 FutureOr<double> initBridge(WebFViewController view, WebFThread runningThread) async {
   // Setup binding bridge.
   BindingBridge.setup();
-  
+
   dartContext ??= DartContext();
 
   double newContextId = runningThread.identity();

--- a/webf/lib/src/bridge/to_native.dart
+++ b/webf/lib/src/bridge/to_native.dart
@@ -625,17 +625,6 @@ void initDartDynamicLinking() {
   _initDartDynamicLinking(NativeApi.initializeApiDLData);
 }
 
-typedef NativeRegisterDartContextFinalizer = Void Function(Handle object, Pointer<Void> dart_context);
-typedef DartRegisterDartContextFinalizer = void Function(Object object, Pointer<Void> dart_context);
-
-final DartRegisterDartContextFinalizer _registerDartContextFinalizer = WebFDynamicLibrary.ref
-    .lookup<NativeFunction<NativeRegisterDartContextFinalizer>>('register_dart_context_finalizer')
-    .asFunction();
-
-void registerDartContextFinalizer(DartContext dartContext) {
-  _registerDartContextFinalizer(dartContext, dartContext.pointer);
-}
-
 typedef NativeRegisterPluginByteCode = Void Function(Pointer<Uint8> bytes, Int32 length, Pointer<Utf8> pluginName);
 typedef DartRegisterPluginByteCode = void Function(Pointer<Uint8> bytes, int length, Pointer<Utf8> pluginName);
 

--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -191,7 +191,7 @@ class WebFViewController implements WidgetsBindingObserver {
       debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
       debugPaintSizeEnabled = true;
     }
-    BindingBridge.setup();
+
     _contextId = await initBridge(this, runningThread);
 
     _setupObserver();


### PR DESCRIPTION
Prior to WebF 0.16.0 "[Add Dedicated Threading support.](https://github.com/openwebf/webf/pull/512)", the JSRuntime lifecycle was managed by the DartIsolateContext lifecycle.

![ui_thread](https://github.com/user-attachments/assets/8e211366-eecd-4326-87e9-98ced7a34938)

But in Dedicated threads, the JSRuntime life cycle must be managed by the WebFPage life cycle, and the `runtime_` redundancy created in DartIsolateContext.

Therefore, JSRuntime lifetime managed by WebFPage lifetime in UI thread mode is more uniform


![page_lifetime](https://github.com/user-attachments/assets/d5ea64e6-feca-40b5-9504-68fb1e245633)
