### PR TITLE
fix: fix crash when clear ui commands without commands.

### DIFF
--- a/.github/workflows/integration_test_flutter.yml
+++ b/.github/workflows/integration_test_flutter.yml
@@ -73,7 +73,7 @@ jobs:
     - run: cd webf && flutter test
 
   integration_test:
-    runs-on: 'macos-14'
+    runs-on: self-hosted
     needs: [ setup, build_bridge ]
     strategy:
       fail-fast: false

--- a/bridge/foundation/shared_ui_command.cc
+++ b/bridge/foundation/shared_ui_command.cc
@@ -44,6 +44,10 @@ void* SharedUICommand::data() {
 }
 
 uint32_t SharedUICommand::kindFlag() {
+  // simply spin wait for the swapBuffers to finish.
+  while (is_blocking_writing_.load(std::memory_order::memory_order_acquire)) {
+  }
+
   return active_buffer->kindFlag();
 }
 
@@ -54,6 +58,9 @@ int64_t SharedUICommand::size() {
 
 // third called by dart to clear commands.
 void SharedUICommand::clear() {
+  // simply spin wait for the swapBuffers to finish.
+  while (is_blocking_writing_.load(std::memory_order::memory_order_acquire)) {
+  }
   active_buffer->clear();
 }
 

--- a/bridge/foundation/ui_command_buffer.cc
+++ b/bridge/foundation/ui_command_buffer.cc
@@ -125,6 +125,7 @@ bool UICommandBuffer::empty() {
 }
 
 void UICommandBuffer::clear() {
+  if (buffer_ == nullptr) return;
   memset(buffer_, 0, sizeof(UICommandItem) * size_);
   size_ = 0;
   kind_flag = 0;


### PR DESCRIPTION
Fix an crash reported by one of our primary customers.

```
Build fingerprint: 'HUAWEI/ALN-AL00/HWALN:12/HUAWEIALN-AL00/104.0.0.165C00:user/release-keys'
#00 0x00000000000db92c /data/app/~~Dn3YtAsInOgqKCZP4g==/Q==/lib/arm64/libwebf.so (BuildId: 0c7f3e4f445ad0da05101c741e1fa30e1e686bec)
                                                                                                                               webf::UICommandBuffer::clear()
                                                                                                                               webf/bridge/foundation/ui_command_buffer.cc:128:46
#01 0x00000000000d5b54 /data/app/~~tAYRj4sInOgqKCZP4g==/4SM56a8_ZSWPTzKpQ==/lib/arm64/libwebf.so (BuildId: 0c7f3e4f445ad0da05101c741e1fa30e1e686bec)
                                                                                                                               webf::SharedUICommand::clear()
                                                                                                                               webf/bridge/foundation/shared_ui_command.cc:57:18
#02 0x00000000000ebdd4 /data/app/~~DAYRj4sInOgqKCZP4g==/K3c4SM56a8_ZSWPTzKpQ==/lib/arm64/libwebf.so (clearUICommandItems+16) (BuildId: 0c7f3e4f445ad0da05101c741e1fa30e1e686bec)
                                                                                                                               clearUICommandItems
                                                                                                                               webf/bridge/webf_bridge.cc:307:48
```