### PR TITLE
refactor(gesture): use tap to simulate double tap

### DIFF
--- a/integration_tests/specs/dom/events/mouseEvent.ts
+++ b/integration_tests/specs/dom/events/mouseEvent.ts
@@ -232,7 +232,7 @@ describe('MouseEvent', () => {
     img2.click();
   })
 
-  xit('should work with dblclick', async (done) => {
+  it('should work with dblclick', async (done) => {
     const div = document.createElement('div');
     div.style.width = '100px';
     div.style.height = '100px';
@@ -244,6 +244,33 @@ describe('MouseEvent', () => {
     await simulateClick(10.0, 10.0, 0);
     await sleep(0.1);
     await simulateClick(10.0, 10.0, 1);
+  });
+
+  it('should work with both click and dblclick', async (done) => {
+    const div = document.createElement('div');
+    div.style.width = '100px';
+    div.style.height = '100px';
+    div.style.backgroundColor = 'red';
+    const events: string[] = [];
+
+    div.addEventListener('click', () => {
+      events.push('click');
+    });
+
+    div.addEventListener('dblclick', () => {
+      events.push('dblclick');
+    });
+
+    document.body.appendChild(div);
+
+    await simulateClick(10.0, 10.0, 0);
+    await sleep(0.1);
+    await simulateClick(10.0, 10.0, 1);
+
+    await sleep(0.1);
+    expect(events).toEqual(['click', 'click', 'dblclick']);
+    document.body.removeChild(div);
+    done();
   });
 
   it('should work with fixed node which be scolled', async () => {

--- a/integration_tests/specs/dom/events/mouseEvent.ts
+++ b/integration_tests/specs/dom/events/mouseEvent.ts
@@ -157,11 +157,11 @@ describe('MouseEvent', () => {
 
     div.addEventListener('click', () => {
       events.push('click');
-    });
+    }, false);
 
     div.addEventListener('dblclick', () => {
       events.push('dblclick');
-    });
+    }, false);
 
     document.body.appendChild(div);
 

--- a/integration_tests/specs/dom/events/mouseEvent.ts
+++ b/integration_tests/specs/dom/events/mouseEvent.ts
@@ -134,6 +134,46 @@ describe('MouseEvent', () => {
     await simulateClick(10.0, 10.0);
   });
 
+  it('should work with dblclick', async (done) => {
+    const div = document.createElement('div');
+    div.style.width = '100px';
+    div.style.height = '100px';
+    div.style.backgroundColor = 'red';
+    div.addEventListener('dblclick', (e) => {
+      done();
+    });
+    document.body.appendChild(div);
+    await simulateClick(10.0, 10.0, 0);
+    await sleep(0.1);
+    await simulateClick(10.0, 10.0, 1);
+  });
+
+  it('should work with both click and dblclick', async () => {
+    const div = document.createElement('div');
+    div.style.width = '100px';
+    div.style.height = '100px';
+    div.style.backgroundColor = 'red';
+    const events: string[] = [];
+
+    div.addEventListener('click', () => {
+      events.push('click');
+    });
+
+    div.addEventListener('dblclick', () => {
+      events.push('dblclick');
+    });
+
+    document.body.appendChild(div);
+
+    await simulateClick(10.0, 10.0, 0);
+    await sleep(0.1);
+    await simulateClick(10.0, 10.0, 1);
+
+    await sleep(0.1);
+    expect(events).toEqual(['click', 'click', 'dblclick']);
+    document.body.removeChild(div);
+  });
+
   it('should work width target', async (done) => {
     const div = document.createElement('div');
     div.style.backgroundColor = 'red';
@@ -231,47 +271,6 @@ describe('MouseEvent', () => {
 
     img2.click();
   })
-
-  it('should work with dblclick', async (done) => {
-    const div = document.createElement('div');
-    div.style.width = '100px';
-    div.style.height = '100px';
-    div.style.backgroundColor = 'red';
-    div.addEventListener('dblclick', (e) => {
-      done();
-    });
-    document.body.appendChild(div);
-    await simulateClick(10.0, 10.0, 0);
-    await sleep(0.1);
-    await simulateClick(10.0, 10.0, 1);
-  });
-
-  it('should work with both click and dblclick', async (done) => {
-    const div = document.createElement('div');
-    div.style.width = '100px';
-    div.style.height = '100px';
-    div.style.backgroundColor = 'red';
-    const events: string[] = [];
-
-    div.addEventListener('click', () => {
-      events.push('click');
-    });
-
-    div.addEventListener('dblclick', () => {
-      events.push('dblclick');
-    });
-
-    document.body.appendChild(div);
-
-    await simulateClick(10.0, 10.0, 0);
-    await sleep(0.1);
-    await simulateClick(10.0, 10.0, 1);
-
-    await sleep(0.1);
-    expect(events).toEqual(['click', 'click', 'dblclick']);
-    document.body.removeChild(div);
-    done();
-  });
 
   it('should work with fixed node which be scolled', async () => {
     const div = document.createElement('div')


### PR DESCRIPTION
In Flutter, if you use GestureDetector to bind both onTap and onDoubleTap events simultaneously, the following situations will occur:

1. When single-clicking, the onTap event will always be triggered with a 300ms delay;
2. When double-clicking, only the onDoubleTap event will be triggered.

webf uses TapGestureRecognizer's onTap and DoubleTapGestureRecognizer's onDoubleTap to handle click and dblclick events, respectively, which leads to the same issues mentioned above.

We expect behavior that aligns with web standards:

1. The bound click event is triggered immediately when a single click occurs.
2. A double-click event within 300ms triggers two click events and one dblclick event.
Therefore, in this case, we use TapGestureRecognizer's onTap to handle both click and dblclick events simultaneously.

Closes #648 