### PR TITLE
fix: submodule mimalloc use git tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "bridge/third_party/quickjs/vendor/mimalloc"]
 	path = bridge/third_party/quickjs/vendor/mimalloc
 	url = https://github.com/microsoft/mimalloc
-	branch = v1.7.9
+	tag = v1.7.9


### PR DESCRIPTION
```
git submodule update --remote
```
Error: `fatal: Unable to find refs/remotes/origin/v1.7.9 revision in submodule path 'bridge/third_party/quickjs/vendor/mimalloc'`, It is possible that the branch is deleted, No problem with tag
