### PR TITLE
feat: support dedicated thread mode in rust mode

### DIFF
--- a/bridge/core/api/executing_context.cc
+++ b/bridge/core/api/executing_context.cc
@@ -27,4 +27,8 @@ WebFValue<SharedExceptionState, ExceptionStatePublicMethods> ExecutingContextWeb
                                                                       ExceptionState::publicMethodPointer(), nullptr);
 }
 
+void ExecutingContextWebFMethods::FinishRecordingUIOperations(webf::ExecutingContext* context) {
+  context->uiCommandBuffer()->AddCommand(UICommand::kFinishRecordingCommand, nullptr, nullptr, nullptr, false);
+}
+
 }  // namespace webf

--- a/bridge/core/executing_context.cc
+++ b/bridge/core/executing_context.cc
@@ -112,6 +112,7 @@ ExecutingContext::ExecutingContext(DartIsolateContext* dart_isolate_context,
 ExecutingContext::~ExecutingContext() {
   is_context_valid_ = false;
   valid_contexts[context_id_] = false;
+  executing_context_status_->disposed = true;
 
   // Check if current context have unhandled exceptions.
   JSValue exception = JS_GetException(script_state_.ctx());

--- a/bridge/core/executing_context.h
+++ b/bridge/core/executing_context.h
@@ -141,6 +141,7 @@ class ExecutingContext {
     assert(dart_isolate_context_->valid());
     return dart_isolate_context_->dartMethodPtr();
   }
+  FORCE_INLINE WebFValueStatus* status() const { return executing_context_status_; }
   FORCE_INLINE ExecutingContextWebFMethods* publicMethodPtr() const { return public_method_ptr_.get(); }
   FORCE_INLINE bool isDedicated() { return is_dedicated_; }
   FORCE_INLINE std::chrono::time_point<std::chrono::system_clock> timeOrigin() const { return time_origin_; }
@@ -216,6 +217,7 @@ class ExecutingContext {
   RejectedPromises rejected_promises_;
   MemberMutationScope* active_mutation_scope{nullptr};
   std::unordered_set<ScriptWrappable*> active_wrappers_;
+  WebFValueStatus* executing_context_status_{new WebFValueStatus()};
   bool is_dedicated_;
 
   // Rust methods ptr should keep alive when ExecutingContext is disposing.

--- a/bridge/core/native/native_loader.cc
+++ b/bridge/core/native/native_loader.cc
@@ -33,17 +33,13 @@ static void ExecuteNativeLibrary(PluginLibraryEntryPoint entry_point,
     native_library_load_context->promise_resolver->Reject(exception_value);
     JS_FreeValue(context->ctx(), exception_value);
   } else {
-    auto exec_status = new WebFValueStatus();
     auto entry_data = WebFValue<ExecutingContext, ExecutingContextWebFMethods>{
-        native_library_load_context->context, native_library_load_context->context->publicMethodPtr(), exec_status};
-    WEBF_LOG(VERBOSE) << " entry_point: " << entry_point;
+        native_library_load_context->context, native_library_load_context->context->publicMethodPtr(),
+        native_library_load_context->context->status()};
     void* result = entry_point(entry_data);
-    WEBF_LOG(VERBOSE) << " result: " << result;
   }
 
   delete native_library_load_context;
-
-  WEBF_LOG(VERBOSE) << " EXEC LIB";
 }
 
 static void HandleNativeLibraryLoad(PluginLibraryEntryPoint entry_point,

--- a/bridge/include/plugin_api/executing_context.h
+++ b/bridge/include/plugin_api/executing_context.h
@@ -18,6 +18,7 @@ class Window;
 using PublicContextGetDocument = WebFValue<Document, DocumentPublicMethods> (*)(ExecutingContext*);
 using PublicContextGetWindow = WebFValue<Window, WindowPublicMethods> (*)(ExecutingContext*);
 using PublicContextGetExceptionState = WebFValue<SharedExceptionState, ExceptionStatePublicMethods> (*)();
+using PublicFinishRecordingUIOperations = void (*)(ExecutingContext* context);
 
 // Memory aligned and readable from WebF side.
 // Only C type member can be included in this class, any C++ type and classes can is not allowed to use here.
@@ -25,11 +26,13 @@ struct ExecutingContextWebFMethods {
   static WebFValue<Document, DocumentPublicMethods> document(ExecutingContext* context);
   static WebFValue<Window, WindowPublicMethods> window(ExecutingContext* context);
   static WebFValue<SharedExceptionState, ExceptionStatePublicMethods> CreateExceptionState();
+  static void FinishRecordingUIOperations(ExecutingContext* context);
 
   double version{1.0};
   PublicContextGetDocument rust_context_get_document_{document};
   PublicContextGetWindow rust_context_get_window_{window};
   PublicContextGetExceptionState rust_context_get_exception_state_{CreateExceptionState};
+  PublicFinishRecordingUIOperations finish_recording_ui_operations{FinishRecordingUIOperations};
 };
 
 }  // namespace webf

--- a/bridge/rusty_webf_sys/src/event_target.rs
+++ b/bridge/rusty_webf_sys/src/event_target.rs
@@ -29,6 +29,7 @@ struct EventCallbackContext {
 struct EventCallbackContextData {
   executing_context_ptr: *const OpaquePtr,
   executing_context_method_pointer: *const ExecutingContextRustMethods,
+  executing_context_status: *const RustValueStatus,
   func: EventListenerCallback,
 }
 
@@ -112,7 +113,7 @@ extern "C" fn handle_event_listener_callback(
   unsafe {
     let func = &(*callback_context_data).func;
     let callback_data = &(*callback_context_data);
-    let executing_context = ExecutingContext::initialize(callback_data.executing_context_ptr, callback_data.executing_context_method_pointer);
+    let executing_context = ExecutingContext::initialize(callback_data.executing_context_ptr, callback_data.executing_context_method_pointer, callback_data.executing_context_status);
     let event = Event::initialize(event_ptr, &executing_context, event_method_pointer, status);
     func(&event);
   }
@@ -148,6 +149,7 @@ impl EventTarget {
     let callback_context_data = Box::new(EventCallbackContextData {
       executing_context_ptr: self.context().ptr,
       executing_context_method_pointer: self.context().method_pointer(),
+      executing_context_status: self.context().status,
       func: callback,
     });
     let callback_context_data_ptr = Box::into_raw(callback_context_data);
@@ -178,6 +180,7 @@ impl EventTarget {
     let callback_context_data = Box::new(EventCallbackContextData {
       executing_context_ptr: self.context().ptr,
       executing_context_method_pointer: self.context().method_pointer(),
+      executing_context_status: self.context().status,
       func: callback,
     });
     let callback_context_data_ptr = Box::into_raw(callback_context_data);

--- a/bridge/rusty_webf_sys/src/lib.rs
+++ b/bridge/rusty_webf_sys/src/lib.rs
@@ -113,7 +113,7 @@ pub struct RustValue<T> {
 }
 
 pub fn initialize_webf_api(value: RustValue<ExecutingContextRustMethods>) -> ExecutingContext {
-  ExecutingContext::initialize(value.value, value.method_pointer)
+  ExecutingContext::initialize(value.value, value.method_pointer, value.status)
 }
 
 // This is the entrypoint when your rust app compiled as dynamic library and loaded & executed by WebF.

--- a/webf/example/lib/main.dart
+++ b/webf/example/lib/main.dart
@@ -42,7 +42,6 @@ class FirstPageState extends State<FirstPage> {
     super.didChangeDependencies();
     controller = WebFController(
       context,
-      runningThread: FlutterUIThread(),
       devToolsService: ChromeDevToolsService(),
     );
     controller.preload(WebFBundle.fromUrl('assets:assets/bundle.html'));


### PR DESCRIPTION
The UICommands created in Rust now work well in dedicated thread mode.

Revert the default thread mode to dedicated in the example project.