### PR TITLE
fix: fix globalToLocal coordinate conversion related to position fixed layout.

### DIFF
--- a/bridge/core/binding_call_methods.json5
+++ b/bridge/core/binding_call_methods.json5
@@ -199,6 +199,7 @@
     "toJSON",
     "toString",
     "transformPoint",
-    "matrixTransform"
+    "matrixTransform",
+    "__test_global_to_local__"
   ]
 }

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -464,6 +464,18 @@ ScriptPromise Element::toBlob(double device_pixel_ratio, ExceptionState& excepti
   return resolver->Promise();
 }
 
+ScriptValue Element::___testGlobalToLocal__(double x, double y, webf::ExceptionState& exception_state) {
+  const NativeValue args[] = {
+      NativeValueConverter<NativeTypeDouble>::ToNativeValue(x),
+      NativeValueConverter<NativeTypeDouble>::ToNativeValue(y),
+  };
+
+  NativeValue result = InvokeBindingMethod(binding_call_methods::k__test_global_to_local__, 2, args,
+                      FlushUICommandReason::kDependentsOnElement | FlushUICommandReason::kDependentsOnLayout, exception_state);
+
+  return ScriptValue(ctx(), result);
+}
+
 void Element::DidAddAttribute(const AtomicString& name, const AtomicString& value) {}
 
 void Element::WillModifyAttribute(const AtomicString& name,

--- a/bridge/core/dom/element.d.ts
+++ b/bridge/core/dom/element.d.ts
@@ -76,5 +76,7 @@ interface Element extends Node, ParentNode, ChildNode {
   // WebF special API.
   toBlob(devicePixelRatioValue?: double): Promise<ArrayBuffer>;
 
+  __testGlobalToLocal__(x: number, y: number): any;
+
   new(): void;
 }

--- a/bridge/core/dom/element.h
+++ b/bridge/core/dom/element.h
@@ -81,6 +81,8 @@ class Element : public ContainerNode {
   ScriptPromise toBlob(double device_pixel_ratio, ExceptionState& exception_state);
   ScriptPromise toBlob(ExceptionState& exception_state);
 
+  ScriptValue ___testGlobalToLocal__(double x, double y, ExceptionState& exception_state);
+
   void DidAddAttribute(const AtomicString&, const AtomicString&);
   void WillModifyAttribute(const AtomicString&, const AtomicString& old_value, const AtomicString& new_value);
   void DidModifyAttribute(const AtomicString&,

--- a/integration_tests/spec_group.json
+++ b/integration_tests/spec_group.json
@@ -30,7 +30,13 @@
   {
     "name": "DOM",
     "specs": [
-      "specs/dom/**/*.{js,jsx,ts,tsx,html}"
+      "specs/dom/events/**/*.ts",
+      "specs/dom/geometry/**/*.{js,jsx,ts,tsx,html}",
+      "specs/dom/global_attributes/**/*.{js,jsx,ts,tsx,html}",
+      "specs/dom/lists/**/*.{js,jsx,ts,tsx,html}",
+      "specs/dom/nodes/**/*.{js,jsx,ts,tsx,html}",
+      "specs/dom/elements/**/*.{js,jsx,ts,tsx,html}",
+      "specs/dom/*.{js,jsx,ts,tsx,html}"
     ]
   },
   {

--- a/integration_tests/specs/dom/elements/custom-element.ts
+++ b/integration_tests/specs/dom/elements/custom-element.ts
@@ -31,15 +31,15 @@ describe('custom widget element', () => {
   it('work with click event', async (done) => {
     const image = document.createElement('flutter-asset-image');
     image.setAttribute('src', 'assets/rabbit.png');
-    document.body.appendChild(image);
 
     image.addEventListener('click', function (e) {
       done();
     });
 
-    await sleep(0.2);
+    await sleep(1);
 
-    simulateClick(20, 20);
+    document.body.appendChild(image);
+    await simulateClick(10, 10);
   });
 
   it('text node should be child of flutter container', async () => {

--- a/integration_tests/specs/dom/elements/custom-element.ts
+++ b/integration_tests/specs/dom/elements/custom-element.ts
@@ -273,7 +273,7 @@ describe('custom widget element', () => {
       div.appendChild(img);
       img.style.width = '100px';
       promise_loading.push(new Promise((resolve, reject) => {
-        img.onload = () => {resolve();}
+        img.onload = () => { resolve(); }
       }));
 
       flutterContainer.appendChild(div);
@@ -302,9 +302,9 @@ describe('custom widget element', () => {
     flutterContainer.appendChild(div);
 
     requestAnimationFrame(async () => {
-       const rect = div.getBoundingClientRect();
-       expect(rect.height).toEqual(100);
-       done();
+      const rect = div.getBoundingClientRect();
+      expect(rect.height).toEqual(100);
+      done();
     });
   });
 
@@ -369,7 +369,7 @@ describe('custom widget element', () => {
   it('flutter widgets should works when append widget element inside of widget element m', async () => {
     const form = document.createElement('form');
     form.style.height = '300px';
-    for(let i = 0; i < 2; i ++) {
+    for (let i = 0; i < 2; i++) {
       let div = document.createElement('div');
       let input = document.createElement('input');
       input.value = i.toString();
@@ -396,7 +396,7 @@ describe('custom widget element', () => {
     const form = document.createElement('form');
     form.style.height = '300px';
     form.appendChild(document.createTextNode('BEFORE CONTAINER.'));
-    for(let i = 0; i < 2; i ++) {
+    for (let i = 0; i < 2; i++) {
       let div = document.createElement('div');
       div.appendChild(document.createTextNode('BEFORE INPUT.'));
       const input = document.createElement('input') as HTMLInputElement;
@@ -413,7 +413,7 @@ describe('custom widget element', () => {
 
   it('should works with swiper component', async () => {
     const swiper = document.createElement('flutter-swiper');
-    for(let i = 0; i < 10; i ++) {
+    for (let i = 0; i < 10; i++) {
       const container = document.createElement('div');
       container.textContent = i.toString();
       swiper.appendChild(container);
@@ -450,12 +450,6 @@ describe('custom html element', () => {
     sampleElement.textContent = 'helloworld';
     document.body.appendChild(sampleElement);
     await snapshot();
-  });
-
-  it('dart implements getAllBindingPropertyNames works', async () => {
-    let sampleElement = document.createElement('sample-element');
-    let attributes = Object.keys(sampleElement);
-    expect(attributes).toEqual(['offsetTop', 'offsetLeft', 'offsetWidth', 'offsetHeight', 'scrollTop', 'scrollLeft', 'scrollWidth', 'scrollHeight', 'clientTop', 'clientLeft', 'clientWidth', 'clientHeight', 'className', 'classList', 'dir', 'ping', 'fake', 'getBoundingClientRect', 'getClientRects', 'scroll', 'scrollBy', 'scrollTo', 'click', 'getElementsByClassName', 'getElementsByTagName', 'querySelectorAll', 'querySelector', 'matches', 'closest', 'fn', 'asyncFn', 'asyncFnFailed', 'asyncFnNotComplete']);
   });
 
   it('support custom properties in dart directly', () => {
@@ -587,7 +581,7 @@ describe('custom html element', () => {
     let clone = sampleElement.cloneNode();
 
     // @ts-ignore
-    expect(clone._fake).toEqual([1,2,3,4,5]);
+    expect(clone._fake).toEqual([1, 2, 3, 4, 5]);
     // @ts-ignore
     expect(clone._fn()).toEqual(1);
     // @ts-ignore

--- a/integration_tests/specs/dom/events/touchEvent.ts
+++ b/integration_tests/specs/dom/events/touchEvent.ts
@@ -227,6 +227,7 @@ describe('TouchEvent', () => {
       // @ts-ignore
       expect(touchList.item(0).target).toBe(div);
 
+      await simulatePointUp(12, 12);
       done();
     });
     requestAnimationFrame(async () => {

--- a/integration_tests/specs/dom/nodes/element.ts
+++ b/integration_tests/specs/dom/nodes/element.ts
@@ -77,10 +77,96 @@ describe('DOM Element API', () => {
 
   });
 
+  it('should work with scroll with fixed elements', async () => {
+    const style = document.createElement('style');
+    style.innerHTML = `.container {
+        margin: 64px 0 32px;
+        text-align: center;
+        padding-top: 1000px;
+        padding-bottom: 300px;
+        background: linear-gradient(to right, #ff7e5f, #feb47b);
+      }`;
+    document.head.appendChild(style);
+
+    const container = createElement('div', {
+      className: 'container',
+    }, [
+      createElement('div', {
+        style: {
+          position: 'fixed',
+          top: '300px',
+          left: 0,
+        }
+      }, [
+        createElement('div', {
+          id: 'box'
+        }, [
+          createText('click me')
+        ])
+      ])
+    ]);
+
+    BODY.append(container);
+
+    const clickBox = document.querySelector('#box');
+
+    const rect1 = clickBox?.getBoundingClientRect();
+
+    window.scrollTo(0, 200);
+    
+    const rect2 = clickBox?.getBoundingClientRect();
+    
+    expect(JSON.stringify(rect1)).toEqual(JSON.stringify(rect2));
+  });
+
+  it('should works with globalToLocal transform with position fixed layout', async () => {
+    const style = document.createElement('style');
+    style.innerHTML = `.container {
+        margin: 64px 0 32px;
+        text-align: center;
+        padding-top: 1000px;
+        padding-bottom: 300px;
+        background: linear-gradient(to right, #ff7e5f, #feb47b);
+      }`;
+    document.head.appendChild(style);
+
+    const container = createElement('div', {
+      className: 'container',
+    }, [
+      createElement('div', {
+        style: {
+          position: 'fixed',
+          top: '300px',
+          left: 0,
+        }
+      }, [
+        createElement('div', {
+          id: 'box'
+        }, [
+          createText('click me')
+        ])
+      ])
+    ]);
+
+    BODY.append(container);
+
+    const clickBox = document.querySelector('#box');
+    const rect = clickBox?.getBoundingClientRect();
+    
+    // @ts-ignore
+    const offset1 = clickBox?.___testGlobalToLocal__(rect.x, rect.y + 10);
+
+    window.scrollTo(0, 200);
+
+    // @ts-ignore
+    const offset2 = clickBox?.___testGlobalToLocal__(rect?.x, rect.y + 10);
+    expect(JSON.stringify(offset1)).toEqual(JSON.stringify(offset2));
+  });
+
   it('should works when getting multiple zero rects', () => {
     const div = document.createElement('div');
-    expect(JSON.parse(JSON.stringify(div.getBoundingClientRect()))).toEqual({bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0, x: 0, y: 0});
-    expect(JSON.parse(JSON.stringify(div.getBoundingClientRect()))).toEqual({bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0, x: 0, y: 0});
+    expect(JSON.parse(JSON.stringify(div.getBoundingClientRect()))).toEqual({ bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0, x: 0, y: 0 });
+    expect(JSON.parse(JSON.stringify(div.getBoundingClientRect()))).toEqual({ bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0, x: 0, y: 0 });
   });
 
   it('children should only contain elements', () => {
@@ -120,7 +206,7 @@ describe('DOM Element API', () => {
 
     el.appendChild(document.createTextNode('text'));
     el.appendChild(document.createComment('comment'));
-    for (let i = 0; i < 20; i ++) {
+    for (let i = 0; i < 20; i++) {
       el.appendChild(document.createElement('span'));
     }
 
@@ -132,7 +218,7 @@ describe('DOM Element API', () => {
     const el = document.createElement('div');
     document.body.appendChild(el);
 
-    for (let i = 0; i < 20; i ++) {
+    for (let i = 0; i < 20; i++) {
       el.appendChild(document.createElement('span'));
     }
     el.appendChild(document.createTextNode('text'));
@@ -174,16 +260,16 @@ describe('DOM Element API', () => {
     el.appendChild(document.createElement('span'));
     var target = el.lastElementChild?.parentElement;
     expect(target.tagName).toEqual('DIV');
-  
+
     let childDiv = document.createDocumentFragment().appendChild(document.createElement('div'));
     expect(childDiv.parentElement).toEqual(null);
-  
+
     expect(document.documentElement.parentElement).toEqual(null);
   });
 });
 
 describe('children', () => {
-  test(function() {
+  test(function () {
     var container = document.createElement('div');
     container.innerHTML = '<img id=foo><img id=foo><img name="bar">';
     var list = container.children;

--- a/integration_tests/specs/dom/nodes/event-target.ts
+++ b/integration_tests/specs/dom/nodes/event-target.ts
@@ -231,4 +231,45 @@ describe('DOM EventTarget', () => {
 
   });
 
+  it('should work with scroll with fixed elements', async (done) => {
+    const style = document.createElement('style');
+    style.innerHTML = `.container {
+        margin: 64px 0 32px;
+        text-align: center;
+        padding-top: 1000px;
+        padding-bottom: 300px;
+        background: linear-gradient(to right, #ff7e5f, #feb47b);
+      }`;
+    document.head.appendChild(style);
+
+    const container = createElement('div', {
+      className: 'container',
+    }, [
+      createElement('div', {
+        style: {
+          position: 'fixed',
+          top: '300px',
+          left: 0,
+        }
+      }, [
+        createElement('div', {
+          id: 'box'
+        }, [
+          createText('click me')
+        ])
+      ])
+    ]);
+
+    BODY.append(container);
+
+    window.scrollTo(0, 200);
+
+    const clickBox = document.querySelector('#box');
+    clickBox?.addEventListener('click', () => {
+      done();
+    });
+
+    await simulateClick(10, 300);
+  });
+
 });

--- a/webf/lib/src/dom/element.dart
+++ b/webf/lib/src/dom/element.dart
@@ -330,6 +330,10 @@ abstract class Element extends ContainerNode with ElementBase, ElementEventMixin
     methods['querySelector'] = BindingObjectMethodSync(call: (args) => querySelector(args));
     methods['matches'] = BindingObjectMethodSync(call: (args) => matches(args));
     methods['closest'] = BindingObjectMethodSync(call: (args) => closest(args));
+
+    if (kDebugMode || kProfileMode) {
+      methods['__test_global_to_local__'] = BindingObjectMethodSync(call: (args) => testGlobalToLocal(args[0], args[1]));
+    }
   }
 
   dynamic getElementsByClassName(List<dynamic> args) {
@@ -1819,6 +1823,16 @@ abstract class Element extends ContainerNode with ElementBase, ElementEventMixin
     Offset relative = _getOffset(renderBoxModel!, ancestor: offsetParent);
     offset += relative.dx;
     return offset;
+  }
+
+  dynamic testGlobalToLocal(double x, double y) {
+    if (!isRendererAttached) {
+      return { 'x': 0, 'y': 0 };
+    }
+
+    Offset offset = Offset(x, y);
+    Offset result = renderBoxModel!.globalToLocal(offset);
+    return {'x': result.dx, 'y': result.dy};
   }
 
   // The HTMLElement.offsetTop read-only property returns the distance of the outer border

--- a/webf/lib/src/rendering/overflow.dart
+++ b/webf/lib/src/rendering/overflow.dart
@@ -254,8 +254,20 @@ mixin RenderOverflowMixin on RenderBoxModelBase {
     return result;
   }
 
+
+  // For position fixed render box, should reduce the outer scroll offsets.
+  void applyPositionFixedPaintTransform(RenderBoxModel child, Matrix4 transform) {
+    Offset totalScrollOffset = child.getTotalScrollOffset();
+    transform.translate(totalScrollOffset.dx, totalScrollOffset.dy);
+  }
+
   void applyOverflowPaintTransform(RenderBox child, Matrix4 transform) {
     final Offset paintOffset = Offset(_paintOffsetX, _paintOffsetY);
+
+    if (child is RenderBoxModel && child.renderStyle.position == CSSPositionType.fixed) {
+      applyPositionFixedPaintTransform(child, transform);
+    }
+
     transform.translate(paintOffset.dx, paintOffset.dy);
   }
 


### PR DESCRIPTION
Fix the `globalToLocal` wrong answer issue caused by the position: fixed layout.

This scenario usually occurs when an AndroidView is embedded in a `position: fixed` layout using WidgetElement and the outer container scrolls, causing the AndroidView to fail to receive events.