### PR TITLE
Fix: Rework inline cache handling.

### DIFF
--- a/bridge/third_party/quickjs/include/quickjs/quickjs.h
+++ b/bridge/third_party/quickjs/include/quickjs/quickjs.h
@@ -742,16 +742,17 @@ JSValue JS_NewArray(JSContext *ctx);
 int JS_IsArray(JSContext *ctx, JSValueConst val);
 
 typedef struct InlineCache InlineCache;
-JSValue JS_GetPropertyInternal(JSContext* ctx, JSValueConst obj, JSAtom prop, JSValueConst receiver, InlineCache *ic, JS_BOOL throw_ref_error);
-JSValue JS_GetPropertyInternalWithIC(JSContext* ctx, JSValueConst obj, JSAtom prop, JSValueConst receiver, InlineCache *ic, int32_t offset, JS_BOOL throw_ref_error);
+typedef struct InlineCacheUpdate InlineCacheUpdate;
+JSValue JS_GetPropertyInternal(JSContext* ctx, JSValueConst obj, JSAtom prop, JSValueConst receiver, InlineCacheUpdate *icu, JS_BOOL throw_ref_error);
+JSValue JS_GetPropertyInternalWithIC(JSContext* ctx, JSValueConst obj, JSAtom prop, JSValueConst receiver, InlineCacheUpdate *icu, JS_BOOL throw_ref_error);
 static js_force_inline JSValue JS_GetProperty(JSContext* ctx, JSValueConst this_obj, JSAtom prop) {
   return JS_GetPropertyInternal(ctx, this_obj, prop, this_obj, NULL, 0);
 }
 JSValue JS_GetPropertyStr(JSContext* ctx, JSValueConst this_obj, const char* prop);
 JSValue JS_GetPropertyUint32(JSContext* ctx, JSValueConst this_obj, uint32_t idx);
 
-int JS_SetPropertyInternal(JSContext* ctx, JSValueConst this_obj, JSAtom prop, JSValue val, int flags, InlineCache *ic);
-int JS_SetPropertyInternalWithIC(JSContext* ctx, JSValueConst this_obj, JSAtom prop, JSValue val, int flags, InlineCache *ic, int32_t offset);
+int JS_SetPropertyInternal(JSContext* ctx, JSValueConst this_obj, JSAtom prop, JSValue val, int flags, InlineCacheUpdate *icu);
+int JS_SetPropertyInternalWithIC(JSContext* ctx, JSValueConst this_obj, JSAtom prop, JSValue val, int flags, InlineCacheUpdate *icu);
 static inline int JS_SetProperty(JSContext* ctx, JSValueConst this_obj, JSAtom prop, JSValue val) {
   return JS_SetPropertyInternal(ctx, this_obj, prop, val, JS_PROP_THROW, NULL);
 }

--- a/bridge/third_party/quickjs/src/core/ic.c
+++ b/bridge/third_party/quickjs/src/core/ic.c
@@ -135,7 +135,7 @@ int free_ic(InlineCache *ic) {
 }
 
 #if _MSC_VER
-uint32_t add_ic_slot(InlineCacheUpdate *icu, JSAtom atom, JSObject *object,
+void add_ic_slot(InlineCacheUpdate *icu, JSAtom atom, JSObject *object,
                      uint32_t prop_offset, JSObject* prototype)
 #else
 force_inline void add_ic_slot(InlineCacheUpdate *icu, JSAtom atom, JSObject *object,

--- a/bridge/third_party/quickjs/src/core/ic.c
+++ b/bridge/third_party/quickjs/src/core/ic.c
@@ -43,8 +43,6 @@ InlineCache *init_ic(JSContext *ctx) {
     goto fail;
   memset(ic->hash, 0, sizeof(ic->hash[0]) * ic->capacity);
   ic->cache = NULL;
-  ic->updated = FALSE;
-  ic->updated_offset = 0;
   return ic;
 fail:
   return NULL;
@@ -137,11 +135,11 @@ int free_ic(InlineCache *ic) {
 }
 
 #if _MSC_VER
-uint32_t add_ic_slot(InlineCache *ic, JSAtom atom, JSObject *object,
+uint32_t add_ic_slot(InlineCacheUpdate *icu, JSAtom atom, JSObject *object,
                      uint32_t prop_offset, JSObject* prototype)
 #else
-force_inline uint32_t add_ic_slot(InlineCache *ic, JSAtom atom, JSObject *object,
-                                  uint32_t prop_offset, JSObject* prototype)
+force_inline void add_ic_slot(InlineCacheUpdate *icu, JSAtom atom, JSObject *object,
+                              uint32_t prop_offset, JSObject* prototype)
 #endif
 {
   int32_t i;
@@ -150,12 +148,19 @@ force_inline uint32_t add_ic_slot(InlineCache *ic, JSAtom atom, JSObject *object
   InlineCacheRingSlot *cr;
   InlineCacheRingItem *ci;
   JSRuntime* rt;
+  InlineCache *ic;
   JSShape *sh;
-  JSObject *proto;
+
+  if (!icu)
+    return;
+  ic = icu->ic;
+
+  if (!ic)
+    return;
+
   cr = NULL;
   rt = ic->ctx->rt;
   sh = NULL;
-  proto = NULL;
   h = get_index_hash(atom, ic->hash_bits);
   for (ch = ic->hash[h]; ch != NULL; ch = ch->next)
     if (ch->atom == atom) {
@@ -197,7 +202,7 @@ force_inline uint32_t add_ic_slot(InlineCache *ic, JSAtom atom, JSObject *object
                           ic_watchpoint_free_handler);
   }
 end:
-  return ch->index;
+  icu->offset = ch->index;
 }
 
 #if _MSC_VER

--- a/bridge/third_party/quickjs/src/core/ic.h
+++ b/bridge/third_party/quickjs/src/core/ic.h
@@ -34,12 +34,13 @@ InlineCache *init_ic(JSContext *ctx);
 int rebuild_ic(InlineCache *ic);
 int resize_ic_hash(InlineCache *ic);
 int free_ic(InlineCache *ic);
-uint32_t add_ic_slot(InlineCache *ic, JSAtom atom, JSObject *object,
+void add_ic_slot(InlineCacheUpdate *icu, JSAtom atom, JSObject *object,
                      uint32_t prop_offset, JSObject* prototype);
 uint32_t add_ic_slot1(InlineCache *ic, JSAtom atom);
-force_inline int32_t get_ic_prop_offset(InlineCache *ic, uint32_t cache_offset,
+force_inline uint32_t get_ic_prop_offset(const InlineCacheUpdate *icu,
                                         JSShape *shape, JSObject **prototype) {
-  uint32_t i;
+  uint32_t i, cache_offset = icu->offset;
+  InlineCache *ic = icu->ic;
   InlineCacheRingSlot *cr;
   InlineCacheRingItem *buffer;
   assert(cache_offset < ic->capacity);
@@ -60,7 +61,7 @@ force_inline int32_t get_ic_prop_offset(InlineCache *ic, uint32_t cache_offset,
   }
 
   *prototype = NULL;
-  return -1;
+  return INLINE_CACHE_MISS;
 }
 
 force_inline JSAtom get_ic_atom(InlineCache *ic, uint32_t cache_offset) {

--- a/bridge/third_party/quickjs/src/core/object.c
+++ b/bridge/third_party/quickjs/src/core/object.c
@@ -389,7 +389,7 @@ JSValue JS_GetPropertyInternal(JSContext *ctx, JSValueConst obj,
                                InlineCacheUpdate *icu,
                                BOOL throw_ref_error)
 {
-  JSObject *p;
+  JSObject *p, *p1;
   JSProperty *pr;
   JSShapeProperty *prs;
   uint32_t tag, offset, proto_depth;
@@ -433,6 +433,7 @@ JSValue JS_GetPropertyInternal(JSContext *ctx, JSValueConst obj,
     p = JS_VALUE_GET_OBJ(obj);
   }
 
+  p1 = p;
   for(;;) {
     prs = find_own_property_ic(&pr, p, prop, &offset);
     if (prs) {
@@ -459,9 +460,9 @@ JSValue JS_GetPropertyInternal(JSContext *ctx, JSValueConst obj,
           continue;
         }
       } else {
-        // basic poly ic and prototype ic is only used for fast path
-        if (icu && proto_depth == 0 && p->shape->is_hashed) {
-          add_ic_slot(icu, prop, p, offset, proto_depth > 0 ? p : NULL);
+        // basic poly ic is only used for fast path
+        if (p1->shape->is_hashed && p->shape->is_hashed) {
+          add_ic_slot(icu, prop, p1, offset, proto_depth > 0 ? p : NULL);
         }
         return JS_DupValue(ctx, pr->u.value);
       }

--- a/bridge/third_party/quickjs/src/core/types.h
+++ b/bridge/third_party/quickjs/src/core/types.h
@@ -562,9 +562,16 @@ typedef struct InlineCache {
     JSContext* ctx;
     InlineCacheHashSlot **hash;
     InlineCacheRingSlot *cache;
-    uint32_t updated_offset;
-    BOOL updated;
 } InlineCache;
+
+#define INLINE_CACHE_MISS ((uint32_t)-1) // sentinel
+// This is a struct so we don't tie up two argument registers in calls to
+// JS_GetPropertyInternal and JS_SetPropertyInternal in the common case
+// where there is no IC and therefore no offset to update.
+typedef struct InlineCacheUpdate {
+  InlineCache *ic;
+  uint32_t offset;
+} InlineCacheUpdate;
 
 typedef struct JSFunctionBytecode {
     JSGCObjectHeader header; /* must come first */


### PR DESCRIPTION
This patch synchronizes the implementation of [quickjs-ng/quickjs#609](https://github.com/quickjs-ng/quickjs/pull/609) with additional support for the prototype IC