### PR TITLE
feat: add console.inspect() API for inspecting JavaScript Objects.

### DIFF
--- a/bridge/polyfill/src/console.ts
+++ b/bridge/polyfill/src/console.ts
@@ -206,6 +206,13 @@ export const console = {
   log(...args: any) {
     printer(logger(arguments));
   },
+  inspect(...args: any) {
+    var result = [];
+    for (var i = 0; i < arguments.length; i++) {
+      result.push(formatter(arguments[i], Number.MAX_VALUE, []));
+    }
+    printer(result.join(SEPARATOR));
+  },
   info(...args: any) {
     printer(logger(arguments), 'info');
   },

--- a/bridge/polyfill/src/console.ts
+++ b/bridge/polyfill/src/console.ts
@@ -55,6 +55,13 @@ function formatter(obj: any, limit: number, stack: Array<any>): string {
   var kind = Object.prototype.toString.call(obj).slice(8, -1);
   if (kind == 'Object') {
     prefix = '';
+  } else if (kind == 'Array') {
+    var itemList: any[] = obj.map((item: any) => formatter(item, limit - 1, stack));
+    return '[' + itemList.join(', ') + ']';
+  } else if (kind == 'Set') {
+    var itemList: any[] = [];
+    obj.forEach((item: any) =>itemList.push(formatter(item, limit - 1, stack)));
+    return 'Set {' + itemList.join(', ') + '}';
   } else {
     prefix = kind + ' ';
     var primitive;
@@ -85,6 +92,10 @@ function formatter(obj: any, limit: number, stack: Array<any>): string {
   stack[stackLength++] = obj;
   var indent = INDENT.repeat(stackLength);
   var keys = Object.getOwnPropertyNames(obj);
+
+  if (obj instanceof Map) {
+    keys = Object.keys(obj);
+  }
 
   var result = prefix + '{';
   if (!keys.length) {


### PR DESCRIPTION
Add a new Console API for inspecting complex JavaScript objects.

Example: 
```javascript
const json = {
    name: 1,
    age: '2',
    map: new Map(),
    set: new Set(),
    fn: function() { return 1; },
    undefined: undefined,
    null: null,
    nest: { nest: {aa: { arr: [1,2,3,4,5]}}}
  };
  json.map['name'] = new Map();
  json.set.add(1);
  json.set.add(2);
  json.map['name']['age'] = [1,2,3,4,5];
  console.inspect(json, 2, 3,4);
```

Result:
```
{
  name: 1, 
  age: '2', 
  map: Map {
    name: Map {
      age: [1, 2, 3, 4, 5]
    }
  }, 
  set: Set {1, 2}, 
  fn: Function {
    length: 0, 
    name: 'fn', 
    prototype: {
      constructor: #
    }
  }, 
  undefined: undefined, 
  null: null, 
  nest: {
    nest: {
      aa: {
        arr: [1, 2, 3, 4, 5]
      }
    }
  }
} 2 3 4
```