### PR TITLE
feat: using std::atomic value types for disposed checks of NativeBindingObject.

### DIFF
--- a/bridge/core/binding_object.cc
+++ b/bridge/core/binding_object.cc
@@ -77,7 +77,7 @@ void NativeBindingObject::HandleCallFromDartSide(const DartIsolateContext* dart_
 BindingObject::BindingObject(JSContext* ctx) : ScriptWrappable(ctx), binding_object_(new NativeBindingObject(this)) {}
 BindingObject::~BindingObject() {
   // Set below properties to nullptr to avoid dart callback to native.
-  binding_object_->disposed_ = true;
+  binding_object_->disposed_.store(true, std::memory_order_release);
   binding_object_->binding_target_ = nullptr;
   binding_object_->invoke_binding_methods_from_dart = nullptr;
   binding_object_->invoke_bindings_methods_from_native = nullptr;

--- a/bridge/core/binding_object.h
+++ b/bridge/core/binding_object.h
@@ -54,12 +54,14 @@ struct NativeBindingObject : public DartReadable {
                                      const NativeValue* argv,
                                      Dart_PersistentHandle dart_object,
                                      DartInvokeResultCallback result_callback);
-
-  bool disposed_{false};
+  static bool IsDisposed(const NativeBindingObject* native_binding_object) {
+    return native_binding_object->disposed_.load(std::memory_order_acquire);
+  }
   BindingObject* binding_target_{nullptr};
   InvokeBindingMethodsFromDart invoke_binding_methods_from_dart{nullptr};
   InvokeBindingsMethodsFromNative invoke_bindings_methods_from_native{nullptr};
   void* extra{nullptr};
+  std::atomic<bool> disposed_{false};
 };
 
 enum BindingMethodCallOperations {

--- a/bridge/include/webf_bridge.h
+++ b/bridge/include/webf_bridge.h
@@ -124,6 +124,12 @@ WEBF_EXPORT_C
 void clearNativeProfileData(void* ptr);
 
 WEBF_EXPORT_C
+void* allocateNativeBindingObject();
+
+WEBF_EXPORT_C
+bool isNativeBindingObjectDisposed(void* native_binding_object);
+
+WEBF_EXPORT_C
 WebFInfo* getWebFInfo();
 WEBF_EXPORT_C
 void dispatchUITask(void* page, void* context, void* callback);

--- a/bridge/webf_bridge.cc
+++ b/bridge/webf_bridge.cc
@@ -3,6 +3,8 @@
  */
 
 #include "include/webf_bridge.h"
+#include <core/binding_object.h>
+
 #include "core/dart_isolate_context.h"
 #include "core/html/parser/html_parser.h"
 #include "core/page.h"
@@ -258,6 +260,14 @@ void collectNativeProfileData(void* ptr, const char** data, uint32_t* len) {
 void clearNativeProfileData(void* ptr) {
   auto* dart_isolate_context = static_cast<webf::DartIsolateContext*>(ptr);
   dart_isolate_context->profiler()->clear();
+}
+
+void* allocateNativeBindingObject() {
+  return new webf::NativeBindingObject(nullptr);
+}
+
+bool isNativeBindingObjectDisposed(void* native_binding_object) {
+  return webf::NativeBindingObject::IsDisposed(static_cast<webf::NativeBindingObject*>(native_binding_object));
 }
 
 void dispatchUITask(void* page_, void* context, void* callback) {

--- a/webf/lib/src/bridge/binding.dart
+++ b/webf/lib/src/bridge/binding.dart
@@ -110,8 +110,8 @@ Future<void> _dispatchEventToNative(Event event, bool isCapture) async {
   if (contextId != null &&
       pointer != null &&
       pointer.ref.invokeBindingMethodFromDart != nullptr &&
-      event.target?.pointer?.ref.disposed != true &&
-      event.currentTarget?.pointer?.ref.disposed != true
+      !isBindingObjectDisposed(event.target?.pointer) &&
+      !isBindingObjectDisposed(event.currentTarget?.pointer)
   ) {
     Completer completer = Completer();
 
@@ -204,7 +204,7 @@ abstract class BindingBridge {
         view.setBindingObject(nativeBindingObject, object);
       }
 
-      if (!nativeBindingObject.ref.disposed) {
+      if (!isBindingObjectDisposed(nativeBindingObject)) {
         nativeBindingObject.ref.invokeBindingMethodFromNative = _invokeBindingMethodFromNative;
       }
     }

--- a/webf/lib/src/gesture/gesture_dispatcher.dart
+++ b/webf/lib/src/gesture/gesture_dispatcher.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:webf/dom.dart';
 import 'package:webf/gesture.dart';
 import 'package:webf/html.dart';
+import 'package:webf/bridge.dart';
 
 class _DragEventInfo extends Drag {
   _DragEventInfo(this.gestureDispatcher);
@@ -432,7 +433,7 @@ class GestureDispatcher {
         // The touch target might be eliminated from the DOM tree and collected by JavaScript GC,
         // resulting in it becoming invisible and inaccessible, yet this change is not synchronized with Dart instantly.
         // Therefore, refrain from triggering events on these unavailable DOM targets.
-        if (touch.target.pointer?.ref.disposed == true) {
+        if (isBindingObjectDisposed(touch.target.pointer)) {
           continue;
         }
 


### PR DESCRIPTION
Fix potential race condition issues when checking the disposed property from the Dart side in multi-threaded mode.