### PR TITLE
Potential fix for code scanning alert no. 46: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,4 +1,6 @@
 name: Create contributors
+permissions:
+  contents: read
 
 on: [workflow_dispatch]
 


### PR DESCRIPTION
Potential fix for [https://github.com/openwebf/webf/security/code-scanning/46](https://github.com/openwebf/webf/security/code-scanning/46)

The best way to fix this problem is to add a `permissions` block to the workflow, either at the root level or specifically within the affected job (`create-contributors-svg`). This block should define the least privileges required for the workflow to operate correctly. In this case, the workflow makes use of the contents of the repository (for checkout and contributor generation), and potentially may need to write files (such as deploying the generated SVG to an OSS bucket), but it doesn't require permissions like `issues: write` or `pull-requests: write`. The recommended minimal permissions are `contents: read`, which allows reading repository contents, but not writing to them. If the deployment or any other job step requires additional permissions (e.g., `contents: write`), these should be scoped only to that job or step. For now, setting `contents: read` at the workflow root adheres to best practices.

To implement this change, add the following block beneath the workflow `name` key in `.github/workflows/contributors.yml`:
```yaml
permissions:
  contents: read
```
No imports or other definitions are needed for a YAML workflow change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->