### PR TITLE
feat: implement `querySelector` and `querySelectorAll` fallback to Blink engine when enabled

### DIFF
--- a/bridge/core/dom/container_node.h
+++ b/bridge/core/dom/container_node.h
@@ -63,6 +63,8 @@ class ContainerNode : public Node {
 
   Element* QuerySelector(const AtomicString& selectors, ExceptionState&);
   Element* QuerySelector(const AtomicString& selectors);
+  std::vector<Element*> QuerySelectorAll(const AtomicString& selectors, ExceptionState&);
+  std::vector<Element*> QuerySelectorAll(const AtomicString& selectors);
 
   Node* InsertBefore(Node* new_child, Node* ref_child, ExceptionState&);
   Node* ReplaceChild(Node* new_child, Node* old_child, ExceptionState&);

--- a/bridge/core/dom/document.cc
+++ b/bridge/core/dom/document.cc
@@ -198,6 +198,10 @@ bool Document::ChildTypeAllowed(NodeType type) const {
 }
 
 Element* Document::querySelector(const AtomicString& selectors, ExceptionState& exception_state) {
+  if (GetExecutingContext() && GetExecutingContext()->isBlinkEnabled()) {
+    return ContainerNode::QuerySelector(selectors, exception_state);
+  }
+
   NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), selectors)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kquerySelector, 1, arguments,
                                            FlushUICommandReason::kDependentsAll, exception_state);
@@ -208,6 +212,10 @@ Element* Document::querySelector(const AtomicString& selectors, ExceptionState& 
 }
 
 std::vector<Element*> Document::querySelectorAll(const AtomicString& selectors, ExceptionState& exception_state) {
+  if (GetExecutingContext() && GetExecutingContext()->isBlinkEnabled()) {
+    return ContainerNode::QuerySelectorAll(selectors, exception_state);
+  }
+
   NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), selectors)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kquerySelectorAll, 1, arguments,
                                            FlushUICommandReason::kDependentsAll, exception_state);

--- a/bridge/core/dom/document_test.cc
+++ b/bridge/core/dom/document_test.cc
@@ -3,6 +3,7 @@
  * Copyright (C) 2022-present The WebF authors. All rights reserved.
  */
 #include "gtest/gtest.h"
+#include "core/dom/document.h"
 #include "webf_test_env.h"
 
 using namespace webf;
@@ -43,6 +44,148 @@ TEST(Document, body) {
   env->page()->evaluateScript(code, strlen(code), "vm://", 0);
   EXPECT_EQ(errorCalled, false);
   EXPECT_EQ(logCalled, true);
+}
+
+TEST(Document, querySelectorUsesBlinkWhenEnabled) {
+  bool static errorCalled = false;
+  bool static logCalled = false;
+  std::string static logMessage;
+  errorCalled = false;
+  logCalled = false;
+  logMessage = "";
+
+  webf::WebFPage::consoleMessageHandler = [](void*, const std::string& message, int) {
+    logCalled = true;
+    logMessage = message;
+  };
+
+  auto env = TEST_init([](double, const char*) { errorCalled = true; }, nullptr, 0, /*enable_blink=*/1);
+  auto* context = env->page()->executingContext();
+  TEST_runLoop(context);
+
+  // Ensure querySelector/querySelectorAll do not fall back to Dart bindings.
+  context->document()->bindingObject()->invoke_bindings_methods_from_native = nullptr;
+
+  const char* code =
+      "let div = document.createElement('div');"
+      "div.id = 'a';"
+      "let span = document.createElement('span');"
+      "span.className = 'b';"
+      "div.appendChild(span);"
+      "document.body.appendChild(div);"
+      "let ok1 = document.querySelector('#a') === div;"
+      "let ok2 = document.querySelector('#a .b') === span;"
+      "let ok3 = document.querySelectorAll('span').length === 1;"
+      "let ok4 = div.querySelector('.b') === span;"
+      "let ok5 = div.querySelectorAll('.b').length === 1;"
+      "let errorName = '';"
+      "try { document.querySelector('['); } catch (e) { errorName = e.name; }"
+      "console.log(ok1 + ' ' + ok2 + ' ' + ok3 + ' ' + ok4 + ' ' + ok5 + ' ' + errorName);";
+
+  env->page()->evaluateScript(code, strlen(code), "vm://", 0);
+  TEST_runLoop(context);
+
+  EXPECT_EQ(errorCalled, false);
+  EXPECT_EQ(logCalled, true);
+  EXPECT_STREQ(logMessage.c_str(), "true true true true true SyntaxError");
+}
+
+TEST(Document, querySelectorAllUsesBlinkWhenEnabledAndKeepsOrder) {
+  bool static errorCalled = false;
+  bool static logCalled = false;
+  std::string static logMessage;
+  errorCalled = false;
+  logCalled = false;
+  logMessage = "";
+
+  webf::WebFPage::consoleMessageHandler = [](void*, const std::string& message, int) {
+    logCalled = true;
+    logMessage = message;
+  };
+
+  auto env = TEST_init([](double, const char*) { errorCalled = true; }, nullptr, 0, /*enable_blink=*/1);
+  auto* context = env->page()->executingContext();
+  TEST_runLoop(context);
+
+  // Ensure querySelector/querySelectorAll do not fall back to Dart bindings.
+  context->document()->bindingObject()->invoke_bindings_methods_from_native = nullptr;
+
+  const char* code =
+      "let d1 = document.createElement('div');"
+      "d1.id = 'd1';"
+      "let s1 = document.createElement('span');"
+      "s1.id = 's1';"
+      "let d2 = document.createElement('div');"
+      "d2.id = 'd2';"
+      "let s2 = document.createElement('span');"
+      "s2.id = 's2';"
+      "document.body.appendChild(d1);"
+      "document.body.appendChild(s1);"
+      "document.body.appendChild(d2);"
+      "document.body.appendChild(s2);"
+      "let list = document.querySelectorAll('div, #s2');"
+      "let ids = '';"
+      "for (let i = 0; i < list.length; i++) { ids += (i ? ',' : '') + list[i].id; }"
+      "let dedup = document.querySelectorAll('div, #d1').length === 2;"
+      "console.log(ids + '|' + dedup);";
+
+  env->page()->evaluateScript(code, strlen(code), "vm://", 0);
+  TEST_runLoop(context);
+
+  EXPECT_EQ(errorCalled, false);
+  EXPECT_EQ(logCalled, true);
+  EXPECT_STREQ(logMessage.c_str(), "d1,d2,s2|true");
+}
+
+TEST(Document, querySelectorSupportsPseudoClassesAndCombinatorsWhenBlinkEnabled) {
+  bool static errorCalled = false;
+  bool static logCalled = false;
+  std::string static logMessage;
+  errorCalled = false;
+  logCalled = false;
+  logMessage = "";
+
+  webf::WebFPage::consoleMessageHandler = [](void*, const std::string& message, int) {
+    logCalled = true;
+    logMessage = message;
+  };
+
+  auto env = TEST_init([](double, const char*) { errorCalled = true; }, nullptr, 0, /*enable_blink=*/1);
+  auto* context = env->page()->executingContext();
+  TEST_runLoop(context);
+
+  // Ensure querySelector/querySelectorAll do not fall back to Dart bindings.
+  context->document()->bindingObject()->invoke_bindings_methods_from_native = nullptr;
+
+  const char* code =
+      "let root = document.createElement('div');"
+      "root.id = 'root';"
+      "let p1 = document.createElement('p');"
+      "p1.setAttribute('data-x', '1');"
+      "let p2 = document.createElement('p');"
+      "p2.setAttribute('data-x', '2');"
+      "let s = document.createElement('span');"
+      "s.className = 'c';"
+      "root.appendChild(p1);"
+      "root.appendChild(p2);"
+      "root.appendChild(s);"
+      "document.body.appendChild(root);"
+      "let ok1 = document.querySelector('#root > p[data-x=\"1\"]') === p1;"
+      "let ok2 = document.querySelector('#root > p[data-x=\"1\"] + p[data-x=\"2\"]') === p2;"
+      "let ok3 = document.querySelector('#root > p:not([data-x=\"1\"])') === p2;"
+      "let ok4 = document.querySelector('#root > p:nth-child(2)') === p2;"
+      "let ok5 = root.querySelector(':scope > span.c') === s;"
+      "let ok6 = root.querySelectorAll(':scope > p').length === 2;"
+      "let ok7 = document.querySelector('#nope') === null;"
+      "let ok8 = document.querySelectorAll('#nope').length === 0;"
+      "console.log(ok1 + ' ' + ok2 + ' ' + ok3 + ' ' + ok4 + ' ' + ok5 + ' ' + ok6 + ' ' + ok7 + ' ' + ok8);";
+
+  env->page()->evaluateScript(code, strlen(code), "vm://", 0);
+  TEST_runLoop(context);
+
+  EXPECT_EQ(errorCalled, false);
+  EXPECT_EQ(logCalled, true);
+  EXPECT_STREQ(logMessage.c_str(), "true true true true true true true true");
 }
 
 TEST(Document, appendParentWillFail) {

--- a/bridge/core/dom/element.cc
+++ b/bridge/core/dom/element.cc
@@ -331,6 +331,10 @@ std::vector<Element*> Element::getElementsByTagName(const AtomicString& tag_name
 }
 
 Element* Element::querySelector(const AtomicString& selectors, ExceptionState& exception_state) {
+  if (GetExecutingContext() && GetExecutingContext()->isBlinkEnabled()) {
+    return ContainerNode::QuerySelector(selectors, exception_state);
+  }
+
   NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), selectors)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kquerySelector, 1, arguments,
                                            FlushUICommandReason::kDependentsAll, exception_state);
@@ -341,6 +345,10 @@ Element* Element::querySelector(const AtomicString& selectors, ExceptionState& e
 }
 
 std::vector<Element*> Element::querySelectorAll(const AtomicString& selectors, ExceptionState& exception_state) {
+  if (GetExecutingContext() && GetExecutingContext()->isBlinkEnabled()) {
+    return ContainerNode::QuerySelectorAll(selectors, exception_state);
+  }
+
   NativeValue arguments[] = {NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), selectors)};
   NativeValue result = InvokeBindingMethod(binding_call_methods::kquerySelectorAll, 1, arguments,
                                            FlushUICommandReason::kDependentsAll, exception_state);


### PR DESCRIPTION
Implements `querySelector`/`querySelectorAll` with a fallback to the Blink engine when enabled.

Changes:
- Add fallback logic in DOM nodes/document/element
- Add unit tests for query selector behavior

Tests:
- `node scripts/run_bridge_unit_test.js` (recommended)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended CSS selector query capabilities to retrieve all matching elements rather than just single results. The implementation now fully supports pseudo-classes, combinators, scope selectors, and provides comprehensive error handling for invalid selector syntax. Results maintain proper ordering and deduplication.

* **Tests**
  * Added comprehensive test coverage for selector functionality including multi-element matching scenarios, complex selector patterns, error cases, and result ordering verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->