### PR TITLE
fix(webf): honor percentage widths for RenderWidget hosted Flutter subtrees

### DIFF
--- a/webf/lib/src/launcher/controller.dart
+++ b/webf/lib/src/launcher/controller.dart
@@ -1190,7 +1190,7 @@ class WebFController with Diagnosticable {
     if (onLoadError != null) {
       onLoadError!(FlutterError(error.toString()), stack);
     }
-    _loadingError = error;
+    _loadingError = '$error\n$stack';
   }
 
   PreRenderingStatus preRenderingStatus = PreRenderingStatus.none;

--- a/webf/lib/src/rendering/widget.dart
+++ b/webf/lib/src/rendering/widget.dart
@@ -155,7 +155,11 @@ class RenderWidget extends RenderBoxModel
     // our content constraints. This allows widget containers to honor fixed
     // widths (e.g., 500px) even when the viewport is narrower, letting them
     // overflow and participate in scrollable sizing like regular layout boxes.
-    if (renderStyle.width.isNotAuto) {
+    // Note: percentage widths can temporarily compute to `auto` (infinity) during
+    // style resolution when the containing block size is not yet known. At layout
+    // time we often do know the used content width (contentBoxLogicalWidth), so
+    // treat any non-AUTO width declaration as eligible for tightening.
+    if (renderStyle.width.type != CSSLengthType.AUTO) {
       final double? logicalContentWidth = renderStyle.contentBoxLogicalWidth;
       if (logicalContentWidth != null && logicalContentWidth.isFinite) {
         final double clampedWidth = logicalContentWidth.clamp(

--- a/webf/test/src/rendering/render_widget_percentage_width_test.dart
+++ b/webf/test/src/rendering/render_widget_percentage_width_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webf/dom.dart' as dom;
+import 'package:webf/webf.dart';
+import 'package:webf/widget.dart';
+import '../widget/test_utils.dart';
+import '../../setup.dart';
+
+class _TestPercentageWidthWidgetElement extends WidgetElement {
+  _TestPercentageWidthWidgetElement(super.context);
+
+  static BoxConstraints? lastLayoutConstraints;
+
+  @override
+  WebFWidgetElementState createState() {
+    return _TestPercentageWidthWidgetElementState(this);
+  }
+}
+
+class _TestPercentageWidthWidgetElementState extends WebFWidgetElementState {
+  _TestPercentageWidthWidgetElementState(super.widgetElement);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
+      _TestPercentageWidthWidgetElement.lastLayoutConstraints = constraints;
+      return const SizedBox.shrink();
+    });
+  }
+}
+
+void main() {
+  const String kProbeTagName = 'WEBF-TEST-PERCENTAGE-WIDTH-WIDGET';
+
+  setUpAll(() {
+    setupTest();
+    if (!dom.getAllWidgetElements().containsKey(kProbeTagName)) {
+      dom.defineWidgetElement(
+        kProbeTagName,
+        (context) => _TestPercentageWidthWidgetElement(context),
+      );
+    }
+  });
+
+  testWidgets('RenderWidget tightens percentage width when definite', (WidgetTester tester) async {
+    final String controllerName = 'render-widget-percentage-width-${DateTime.now().millisecondsSinceEpoch}';
+    _TestPercentageWidthWidgetElement.lastLayoutConstraints = null;
+
+    await WebFWidgetTestUtils.prepareWidgetTest(
+      tester: tester,
+      controllerName: controllerName,
+      viewportWidth: 360,
+      viewportHeight: 640,
+      html: '''
+        <body style="margin: 0">
+          <div style="width: 320px;">
+            <webf-test-percentage-width-widget
+              id="probe"
+              style="display: block; width: 100%;"
+            ></webf-test-percentage-width-widget>
+          </div>
+        </body>
+      ''',
+      wrap: (Widget webf) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: webf,
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    final BoxConstraints? constraints = _TestPercentageWidthWidgetElement.lastLayoutConstraints;
+    expect(constraints, isNotNull);
+    expect(constraints!.minWidth, closeTo(320.0, 0.01));
+    expect(constraints.maxWidth, closeTo(320.0, 0.01));
+  });
+}


### PR DESCRIPTION
## Summary
- Tighten RenderWidget layout constraints for any non-AUTO `width` declaration so percentage widths (e.g. `width: 100%`) are honored once a definite containing block width is known.
- Include stack traces in `WebFController.loadingError` for easier debugging.

## Tests
- `cd webf && flutter test test/src/rendering/render_widget_percentage_width_test.dart`
