### PR TITLE
fix: add support for Flutter 3.41.x

### DIFF
--- a/webf/lib/src/launcher/view_controller.dart
+++ b/webf/lib/src/launcher/view_controller.dart
@@ -1398,6 +1398,12 @@ class WebFViewController with Diagnosticable implements WidgetsBindingObserver {
   void didChangeViewFocus(event) {}
 
   @override
+  void handleStatusBarTap() {
+    // Matches iOS browser behavior: tapping the status bar scrolls the page to the top.
+    window.scrollTo(0, 0, true);
+  }
+
+  @override
   String toStringShort() {
     return describeIdentity(this);
   }


### PR DESCRIPTION
Fixed https://github.com/openwebf/webf/issues/862

## Summary
- Adds `handleStatusBarTap()` override to `WebFViewController` to comply with the updated `WidgetsBindingObserver` interface in Flutter 3.41.x
- Implements iOS-native behavior: tapping the status bar scrolls the page to the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)