### PR TITLE
fix: widen archive and intl constraints for Flutter 3.27+

### DIFF
--- a/webf/pubspec.yaml
+++ b/webf/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   async: ^2.8.2 # Pure dart module.
   quiver: ^3.2.1 # Pure dart module.
   source_span: ^1.9.0 # Pure dart module.
-  archive: ^3.3.7 # Pure dart module.
+  archive: ">=3.3.7 <5.0.0" # Pure dart module.
   web_socket_channel: ^3.0.1
   flutter_svg: ^2.0.17
   webf_easy_refresh: ^3.4.1
@@ -27,7 +27,7 @@ dependencies:
   shelf_web_socket: ^2.0.1
   crypto: ^3.0.6
   logging: ^1.3.0
-  intl: ^0.19.0
+  intl: ">=0.19.0 <0.21.0"
   vector_math: ^2.1.2
   dio: ^5.4.0
   http: ^1.5.0


### PR DESCRIPTION
## Summary

- `archive: ^3.3.7` → `>=3.3.7 <5.0.0`
- `intl: ^0.19.0` → `>=0.19.0 <0.21.0`

## Problem

Flutter 3.27+ ships `flutter_localizations` which pins `intl: 0.20.2`. This conflicts with WebF's `intl: ^0.19.0` constraint (caps at `<0.20.0`), making it impossible to use WebF without `dependency_overrides`.

Similarly, `archive` 4.x is now common in the ecosystem. WebF only uses `GZipDecoder` which is stable across 3.x → 4.x, but `^3.3.7` blocks resolution when another dependency requires `archive: ^4.0.0`.

## Changes

Widened both constraints to allow the newer major versions while keeping backward compatibility with the minimum versions WebF already supports.

## Testing

- Built and tested with Flutter 3.27 on macOS — compiles and runs without issues.
- No API changes needed — `GZipDecoder().decodeBytes()` and all `intl` usage work identically with the newer versions.