### PR TITLE
perf(websocket): remove Dart-side listener gate to eliminate sync inv…

### DIFF
--- a/bridge/polyfill/src/websocket.ts
+++ b/bridge/polyfill/src/websocket.ts
@@ -141,11 +141,6 @@ export class WebSocket extends EventTarget implements WebSocketInterface {
     initPropertyHandlersForEventTargets(this, builtInEvents$1);
   }
 
-  addEventListener(type: string, callback: EventListener | EventListenerObject) {
-    webf.invokeModule('WebSocket', 'addEvent', this.id, type);
-    super.addEventListener(type, callback);
-  }
-
   // TODO add blob arrayBuffer ArrayBufferView format support
   send(message: string) {
     webf.invokeModule('WebSocket', 'send', this.id, message);

--- a/integration_tests/spec_group.json5
+++ b/integration_tests/spec_group.json5
@@ -145,5 +145,11 @@
     "specs": [
       "specs/rust/**/*.{js,jsx,ts,tsx,html}"
     ]
+  },
+  {
+    "name": "WebSocket",
+    "specs": [
+      "specs/websocket/**/*.{js,jsx,ts,tsx,html}"
+    ]
   }
 ]

--- a/integration_tests/specs/dom/lists/webf_listview_scroll_by_index.ts
+++ b/integration_tests/specs/dom/lists/webf_listview_scroll_by_index.ts
@@ -1,5 +1,5 @@
 describe('WebFListView.scrollByIndex', () => {
-  fit('should scroll to the last item by index', async (done) => {
+  it('should scroll to the last item by index', async (done) => {
     const listview = document.createElement('webf-listview') as any;
     listview.style.width = '300px';
     listview.style.height = '200px';

--- a/integration_tests/specs/websocket/websocket.ts
+++ b/integration_tests/specs/websocket/websocket.ts
@@ -52,4 +52,66 @@ describe('WebSocket', () => {
       done();
     };
   });
+
+  // Regression test: verify that open/message/close events are correctly
+  // dispatched after removing the Dart-side _listenMap gate.
+  // Previously, addEventListener called invokeModule('WebSocket', 'addEvent')
+  // to register interest in Dart; now Dart fires unconditionally and the
+  // JS-side EventTarget handles dispatch filtering.
+
+  it('open event fires when listener registered via onopen property', (done) => {
+    let ws = new WebSocket(`ws://127.0.0.1:${window['WEBSOCKET_PORT']}`);
+    ws.onopen = () => {
+      expect(ws.readyState).toBe(1); // WebSocket.OPEN = 1
+      ws.close();
+      done();
+    };
+  });
+
+  it('open event fires when listener registered via addEventListener', (done) => {
+    let ws = new WebSocket(`ws://127.0.0.1:${window['WEBSOCKET_PORT']}`);
+    ws.addEventListener('open', () => {
+      expect(ws.readyState).toBe(1); // WebSocket.OPEN = 1
+      ws.close();
+      done();
+    });
+  });
+
+  it('no open event fired when no listener registered', (done) => {
+    // Dart now fires open unconditionally; without a JS listener nothing
+    // should throw and the connection should still close cleanly.
+    let ws = new WebSocket(`ws://127.0.0.1:${window['WEBSOCKET_PORT']}`);
+    // Intentionally no onopen listener
+    ws.onclose = () => {
+      done();
+    };
+    setTimeout(() => {
+      ws.close();
+    }, 100);
+  });
+
+  it('message event fires after open without addEvent gate', (done) => {
+    let ws = new WebSocket(`ws://127.0.0.1:${window['WEBSOCKET_PORT']}`);
+    ws.onopen = () => {
+      ws.send('ping');
+    };
+    ws.onmessage = (event) => {
+      // Server sends 'something' on connect, then echoes 'receive: ping'
+      if (event.data === 'receive: ping') {
+        ws.close();
+        done();
+      }
+    };
+  });
+
+  it('close event fires after connection closed', (done) => {
+    let ws = new WebSocket(`ws://127.0.0.1:${window['WEBSOCKET_PORT']}`);
+    ws.onopen = () => {
+      ws.close();
+    };
+    ws.onclose = (event) => {
+      expect(ws.readyState).toBe(3); // WebSocket.CLOSED = 3
+      done();
+    };
+  });
 });

--- a/webf/lib/src/module/websocket.dart
+++ b/webf/lib/src/module/websocket.dart
@@ -24,7 +24,6 @@ class WebSocketModule extends BaseModule {
   String get name => 'WebSocket';
 
   final Map<String, IOWebSocketChannel> _clientMap = {};
-  final Map<String?, Map<String?, bool>> _listenMap = {};
   final Map<String?, _WebSocketState> _stateMap = {};
   int _clientId = 0;
 
@@ -37,8 +36,6 @@ class WebSocketModule extends BaseModule {
       return init(params[0], (String id, Event event) {
         moduleManager!.emitModuleEvent(name, event: event, data: id);
       }, protocols: protocols);
-    } else if (method == 'addEvent') {
-      addEvent(params[0], params[1]);
     } else if (method == 'send') {
       send(params[0], params[1]);
     } else if (method == 'close') {
@@ -53,7 +50,6 @@ class WebSocketModule extends BaseModule {
       socket.sink.close();
     });
     _clientMap.clear();
-    _listenMap.clear();
     _stateMap.clear();
   }
 
@@ -74,17 +70,15 @@ class WebSocketModule extends BaseModule {
         return;
       }
       _clientMap[id] = client;
-      // Listen all event
+      // Listen all events
       _listen(id, callback);
-      if (_hasListener(id, EVENT_OPEN)) {
-        Event event = Event(EVENT_OPEN);
-        callback(id, event);
-      }
+      // Unconditionally fire open event; JS-side EventTarget will dispatch
+      // only if a listener is registered (no need for a Dart-side gate).
+      callback(id, Event(EVENT_OPEN));
     }).catchError((e, stack) {
       // print connection error internally and trigger error event.
       print(e);
-      Event event = Event(EVENT_ERROR);
-      callback(id, event);
+      callback(id, Event(EVENT_ERROR));
     });
 
     return id;
@@ -117,50 +111,23 @@ class WebSocketModule extends BaseModule {
     client.sink.close(closeCode, closeReason);
   }
 
-  bool _hasListener(String id, String type) {
-    if (!_listenMap.containsKey(id)) return false;
-    var listeners = _listenMap[id]!;
-    return listeners.containsKey(type);
-  }
-
   void _listen(String id, WebSocketEventCallback callback) {
     IOWebSocketChannel client = _clientMap[id]!;
 
     client.stream.listen((message) {
-      if (!_hasListener(id, EVENT_MESSAGE)) return;
-      MessageEvent event = MessageEvent(message);
-      callback(id, event);
+      callback(id, MessageEvent(message));
     }, onError: (error) {
-      if (!_hasListener(id, EVENT_ERROR)) return;
       // print error internally and trigger error event;
       print(error);
-      Event event = Event(EVENT_ERROR);
-      callback(id, event);
+      callback(id, Event(EVENT_ERROR));
     }, onDone: () {
       if (moduleManager?.disposed == true) return;
 
-      if (_hasListener(id, EVENT_CLOSE)) {
-        // CloseEvent https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/CloseEvent
-        CloseEvent event = CloseEvent(client.closeCode!, client.closeReason ?? '', false);
-        callback(id, event);
-      }
+      // CloseEvent https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/CloseEvent
+      callback(id, CloseEvent(client.closeCode ?? 1000, client.closeReason ?? '', false));
       // Clear instance after close
-      _listenMap.remove(id);
       _clientMap.remove(id);
       _stateMap.remove(id);
     });
-  }
-
-  void addEvent(String? id, String? type) {
-    if (moduleManager?.disposed == true) return;
-
-    if (!_listenMap.containsKey(id)) {
-      // Init listener map
-      _listenMap[id] = {};
-    }
-
-    // Mark event type listened
-    var listeners = _listenMap[id]!;
-    listeners[type] = true;
   }
 }


### PR DESCRIPTION
Problem

When calling ws.onopen = handler (or any of onmessage, onerror, onclose), the WebSocket polyfill overrode addEventListener to call invokeModule('WebSocket', 'addEvent', ...) synchronously. This triggered FlushUICommand + PostToDartSync on every assignment, blocking the JS thread for ~28ms each — totaling ~113ms per connect() call.

The root cause: Dart's WebSocketModule used a _listenMap gate to decide whether to fire events, requiring JS to pre-register interest via addEvent. This gate was redundant because EventTarget.dispatchEvent already performs the same check internally — if no listener is registered, the event is silently dropped.

Solution

Remove the Dart-side listener gate entirely:

Delete _listenMap, _hasListener, and addEvent from WebSocketModule
Fire open, message, error, close events unconditionally; JS-side EventTarget handles dispatch filtering
Fix null safety issue: use closeCode ?? 1000 instead of closeCode! in onDone callback
Remove the addEventListener override in websocket.ts that called invokeModule('addEvent')
Impact

Eliminates 4 synchronous invokeModule calls per WebSocket connection (~113ms JS thread blocking)
No behavior change: events are still only delivered to registered listeners
Testing

Added 5 regression tests to 
websocket.ts
 covering open/message/close event dispatch without the listener gate. All 9 WebSocket tests pass.