### PR TITLE
perf(image): make HTMLImageElement.src setter async

### DIFF
--- a/bridge/core/html/html_image_element.cc
+++ b/bridge/core/html/html_image_element.cc
@@ -34,8 +34,26 @@ AtomicString HTMLImageElement::src() const {
 }
 
 void HTMLImageElement::setSrc(const AtomicString& value, ExceptionState& exception_state) {
-  SetBindingProperty(binding_call_methods::ksrc, NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), value),
-                     exception_state);
+  // Queue a UI command rather than going through the sync bridge path:
+  //
+  //   * `src` is fire-and-forget — JS never reads anything synchronously
+  //     out of the setter, the actual network load is async on Dart, and
+  //     any subsequent `img.src` getter / `getProperty` call calls
+  //     `FlushUICommand` internally before its sync read so it still sees
+  //     the value just written.
+  //   * The sync path forced a per-write FlushUICommand, which during
+  //     React commit + image-load swap bursts triggered cascading
+  //     styleRecalc walks (~2k recalcs per insert in profiles). Folding
+  //     these writes into the next natural flush eliminates the
+  //     amplification.
+  //
+  // The HTMLImageElement attribute mirror is unchanged: `attributes_` is
+  // only kept in sync for `WidgetElement`, and the WidgetElement-only
+  // branch in `BindingObject::SetBindingProperty` is preserved by the
+  // remaining sync setters that need it.
+  SetBindingPropertyAsync(binding_call_methods::ksrc,
+                          NativeValueConverter<NativeTypeString>::ToNativeValue(ctx(), value),
+                          exception_state);
   if (!value.IsEmpty() && !keep_alive) {
     KeepAlive();
     keep_alive = true;


### PR DESCRIPTION
## Summary

- Route `img.src = url` through `SetBindingPropertyAsync` instead of the sync `SetBindingProperty` path.
- The sync path forced a `FlushUICommand` per write plus a sync FFI round-trip; both are unnecessary for `src` because the setter is fire-and-forget, the network load is async on Dart anyway, and any subsequent JS read of `img.src` already calls `FlushUICommand` internally before its sync read so it still sees the just-written value.
- Read-after-write semantics, MutationObserver behavior (which never fired for HTMLImageElement to begin with), and the `attributes_` mirror are all preserved.

## Why

In profiles of the OTC mini-program, 59 sync `setProperty(src)` calls in a single route render burst forced 59 separate `FlushUICommand` drains. Each drain entered the styleRecalc cascade producing ~2,000 nested recalc spans per inserted node, contributing to a 16,500-span recalc total (1.69 s self) during the hot 67–69 s window with two 246 ms / 196 ms drawFrames.

Folding these writes into the next natural flush should drop ~250 ms of JS-thread block plus ~600-800 ms of cascading Dart-side styleRecalc work, smoothing the worst frames in the burst.

## What's preserved

| read scenario | today | after this PR |
|---|---|---|
| `img.src` getter immediately after write | flush + sync read returns new value | flush + sync read returns new value (`GetBindingProperty` calls `FlushUICommand` before the sync read at `binding_object.cc:311`) |
| `img.src = url1; img.src = url2;` (last-wins) | last value wins on Dart immediately | last value wins on Dart at next flush |
| `img.getAttribute('src')` after `img.setAttribute('src', url)` | returns `url` | returns `url` (unchanged path through `ElementAttributes::setAttribute`) |
| `img.getAttribute('src')` after `img.src = url` | returns `null`* | returns `null`* (pre-existing limitation, attributes_ mirror is `WidgetElement`-only) |

\* Pre-existing limitation; not introduced by this PR.

The only actual semantic change is **a ≤ 1-frame delay before the network load starts on the Dart side**. In practice that's smaller than today's per-write flush stalls (38 ms p95, 250+ ms tail).

## Test plan

- [ ] Build bridge: `npm run build:bridge:macos`
- [ ] Existing image tests still pass: `cd integration_tests && npm run integration` (image-related specs in particular)
- [ ] New regression check: `img.src = url; expect(img.src).toBe(url)` returns the just-set value (validates the read-side flush trigger)
- [ ] Image `onload` fires correctly after `img.src = url` (load lifecycle)
- [ ] Re-capture profile from same flow that produced 59-call burst; confirm count drops and styleRecalc cascade shrinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)